### PR TITLE
ci(workflow): remove social media inputs from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,4 @@ jobs:
       extension-name: MCPServer
       display-name: 'MCP Server'
       marketplace-id: CodingWithCalvin.VS-MCPServer
-      description: 'Visual Studio extension that exposes VS features as an MCP server for AI assistants'
-      hashtags: ''
     secrets: inherit


### PR DESCRIPTION
## Summary
- Remove social media inputs (`description`, `hashtags`) from publish workflow that are no longer used by the reusable vsix-publish workflow

## Test plan
- [ ] Verify publish workflow still works correctly