### PR TITLE
feat(tools): add document_save MCP tool

### DIFF
--- a/src/CodingWithCalvin.MCPServer.Server/RpcClient.cs
+++ b/src/CodingWithCalvin.MCPServer.Server/RpcClient.cs
@@ -109,6 +109,7 @@ public class RpcClient : IVisualStudioRpc, IServerRpc, IDisposable
     public Task<DocumentInfo?> GetActiveDocumentAsync() => Proxy.GetActiveDocumentAsync();
     public Task<bool> OpenDocumentAsync(string path) => Proxy.OpenDocumentAsync(path);
     public Task<bool> CloseDocumentAsync(string path, bool save) => Proxy.CloseDocumentAsync(path, save);
+    public Task<bool> SaveDocumentAsync(string path) => Proxy.SaveDocumentAsync(path);
     public Task<string?> ReadDocumentAsync(string path) => Proxy.ReadDocumentAsync(path);
     public Task<bool> WriteDocumentAsync(string path, string content) => Proxy.WriteDocumentAsync(path, content);
     public Task<SelectionInfo?> GetSelectionAsync() => Proxy.GetSelectionAsync();

--- a/src/CodingWithCalvin.MCPServer.Server/Tools/DocumentTools.cs
+++ b/src/CodingWithCalvin.MCPServer.Server/Tools/DocumentTools.cs
@@ -63,6 +63,15 @@ public class DocumentTools
         return success ? $"Closed: {path}" : $"Document not found or failed to close: {path}";
     }
 
+    [McpServerTool(Name = "document_save", Destructive = false, Idempotent = true)]
+    [Description("Save an open document in Visual Studio to disk.")]
+    public async Task<string> SaveDocumentAsync(
+        [Description("The full absolute path to the document. Must be open in VS. Get the path from document_list. Supports forward slashes (/) or backslashes (\\).")] string path)
+    {
+        var success = await _rpcClient.SaveDocumentAsync(path);
+        return success ? $"Saved: {path}" : $"Document not found or failed to save: {path}";
+    }
+
     [McpServerTool(Name = "document_read", ReadOnly = true)]
     [Description("Read the contents of a document. If the document is open in VS, reads the current editor buffer (including unsaved changes); otherwise reads from disk.")]
     public async Task<string> ReadDocumentAsync(

--- a/src/CodingWithCalvin.MCPServer.Shared/RpcContracts.cs
+++ b/src/CodingWithCalvin.MCPServer.Shared/RpcContracts.cs
@@ -19,6 +19,7 @@ public interface IVisualStudioRpc
     Task<DocumentInfo?> GetActiveDocumentAsync();
     Task<bool> OpenDocumentAsync(string path);
     Task<bool> CloseDocumentAsync(string path, bool save);
+    Task<bool> SaveDocumentAsync(string path);
     Task<string?> ReadDocumentAsync(string path);
     Task<bool> WriteDocumentAsync(string path, string content);
     Task<SelectionInfo?> GetSelectionAsync();

--- a/src/CodingWithCalvin.MCPServer/Services/IVisualStudioService.cs
+++ b/src/CodingWithCalvin.MCPServer/Services/IVisualStudioService.cs
@@ -15,6 +15,7 @@ public interface IVisualStudioService
     Task<DocumentInfo?> GetActiveDocumentAsync();
     Task<bool> OpenDocumentAsync(string path);
     Task<bool> CloseDocumentAsync(string path, bool save = true);
+    Task<bool> SaveDocumentAsync(string path);
     Task<string?> ReadDocumentAsync(string path);
     Task<bool> WriteDocumentAsync(string path, string content);
     Task<SelectionInfo?> GetSelectionAsync();

--- a/src/CodingWithCalvin.MCPServer/Services/RpcServer.cs
+++ b/src/CodingWithCalvin.MCPServer/Services/RpcServer.cs
@@ -169,6 +169,7 @@ public class RpcServer : IRpcServer, IVisualStudioRpc
     public Task<DocumentInfo?> GetActiveDocumentAsync() => _vsService.GetActiveDocumentAsync();
     public Task<bool> OpenDocumentAsync(string path) => _vsService.OpenDocumentAsync(path);
     public Task<bool> CloseDocumentAsync(string path, bool save) => _vsService.CloseDocumentAsync(path, save);
+    public Task<bool> SaveDocumentAsync(string path) => _vsService.SaveDocumentAsync(path);
     public Task<string?> ReadDocumentAsync(string path) => _vsService.ReadDocumentAsync(path);
     public Task<bool> WriteDocumentAsync(string path, string content) => _vsService.WriteDocumentAsync(path, content);
     public Task<SelectionInfo?> GetSelectionAsync() => _vsService.GetSelectionAsync();

--- a/src/CodingWithCalvin.MCPServer/Services/VisualStudioService.cs
+++ b/src/CodingWithCalvin.MCPServer/Services/VisualStudioService.cs
@@ -205,6 +205,30 @@ public class VisualStudioService : IVisualStudioService
         return false;
     }
 
+    public async Task<bool> SaveDocumentAsync(string path)
+    {
+        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+        var dte = await GetDteAsync();
+
+        foreach (Document doc in dte.Documents)
+        {
+            try
+            {
+                if (PathsEqual(doc.FullName, path))
+                {
+                    doc.Save();
+                    return true;
+                }
+            }
+            catch (Exception ex)
+            {
+                VsixTelemetry.TrackException(ex);
+            }
+        }
+
+        return false;
+    }
+
     public async Task<string?> ReadDocumentAsync(string path)
     {
         await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();


### PR DESCRIPTION
## Summary
- Adds a new `document_save` MCP tool that saves an open document to disk without closing it
- Wired through the full chain: MCP tool → RpcClient → RpcServer → VisualStudioService → DTE `doc.Save()`

## Test plan
- [ ] Open a document in VS, make changes, call `document_save` with the file path — verify file is saved
- [ ] Call `document_save` on a document that isn't open — verify failure message returned
- [ ] Call `document_save` on an already-saved document — verify idempotent success

Closes #36 