### PR TITLE
fix(tools): use native ReplacePattern for editor_replace tool

### DIFF
--- a/src/CodingWithCalvin.MCPServer.Server/RpcClient.cs
+++ b/src/CodingWithCalvin.MCPServer.Server/RpcClient.cs
@@ -116,7 +116,7 @@ public class RpcClient : IVisualStudioRpc, IServerRpc, IDisposable
     public Task<bool> SetSelectionAsync(string path, int startLine, int startColumn, int endLine, int endColumn)
         => Proxy.SetSelectionAsync(path, startLine, startColumn, endLine, endColumn);
     public Task<bool> InsertTextAsync(string text) => Proxy.InsertTextAsync(text);
-    public Task<bool> ReplaceTextAsync(string oldText, string newText) => Proxy.ReplaceTextAsync(oldText, newText);
+    public Task<int> ReplaceTextAsync(string oldText, string newText) => Proxy.ReplaceTextAsync(oldText, newText);
     public Task<bool> GoToLineAsync(int line) => Proxy.GoToLineAsync(line);
     public Task<List<FindResult>> FindAsync(string searchText, bool matchCase, bool wholeWord)
         => Proxy.FindAsync(searchText, matchCase, wholeWord);

--- a/src/CodingWithCalvin.MCPServer.Server/Tools/DocumentTools.cs
+++ b/src/CodingWithCalvin.MCPServer.Server/Tools/DocumentTools.cs
@@ -164,8 +164,8 @@ public class DocumentTools
         [Description("The exact text to find (case-sensitive).")] string oldText,
         [Description("The replacement text. Use empty string to delete matches.")] string newText)
     {
-        var success = await _rpcClient.ReplaceTextAsync(oldText, newText);
-        return success ? "Text replaced" : "Text not found or no active document";
+        var count = await _rpcClient.ReplaceTextAsync(oldText, newText);
+        return count > 0 ? $"Replaced {count} occurrence(s)" : "Text not found or no active document";
     }
 
     [McpServerTool(Name = "editor_goto_line", Destructive = false, Idempotent = true)]

--- a/src/CodingWithCalvin.MCPServer.Shared/RpcContracts.cs
+++ b/src/CodingWithCalvin.MCPServer.Shared/RpcContracts.cs
@@ -26,7 +26,7 @@ public interface IVisualStudioRpc
     Task<bool> SetSelectionAsync(string path, int startLine, int startColumn, int endLine, int endColumn);
 
     Task<bool> InsertTextAsync(string text);
-    Task<bool> ReplaceTextAsync(string oldText, string newText);
+    Task<int> ReplaceTextAsync(string oldText, string newText);
     Task<bool> GoToLineAsync(int line);
     Task<List<FindResult>> FindAsync(string searchText, bool matchCase, bool wholeWord);
 

--- a/src/CodingWithCalvin.MCPServer/Services/IVisualStudioService.cs
+++ b/src/CodingWithCalvin.MCPServer/Services/IVisualStudioService.cs
@@ -22,7 +22,7 @@ public interface IVisualStudioService
     Task<bool> SetSelectionAsync(string path, int startLine, int startColumn, int endLine, int endColumn);
 
     Task<bool> InsertTextAsync(string text);
-    Task<bool> ReplaceTextAsync(string oldText, string newText);
+    Task<int> ReplaceTextAsync(string oldText, string newText);
     Task<bool> GoToLineAsync(int line);
     Task<List<FindResult>> FindAsync(string searchText, bool matchCase = false, bool wholeWord = false);
 

--- a/src/CodingWithCalvin.MCPServer/Services/RpcServer.cs
+++ b/src/CodingWithCalvin.MCPServer/Services/RpcServer.cs
@@ -176,7 +176,7 @@ public class RpcServer : IRpcServer, IVisualStudioRpc
     public Task<bool> SetSelectionAsync(string path, int startLine, int startColumn, int endLine, int endColumn)
         => _vsService.SetSelectionAsync(path, startLine, startColumn, endLine, endColumn);
     public Task<bool> InsertTextAsync(string text) => _vsService.InsertTextAsync(text);
-    public Task<bool> ReplaceTextAsync(string oldText, string newText) => _vsService.ReplaceTextAsync(oldText, newText);
+    public Task<int> ReplaceTextAsync(string oldText, string newText) => _vsService.ReplaceTextAsync(oldText, newText);
     public Task<bool> GoToLineAsync(int line) => _vsService.GoToLineAsync(line);
     public Task<List<FindResult>> FindAsync(string searchText, bool matchCase, bool wholeWord)
         => _vsService.FindAsync(searchText, matchCase, wholeWord);

--- a/src/CodingWithCalvin.MCPServer/Services/VisualStudioService.cs
+++ b/src/CodingWithCalvin.MCPServer/Services/VisualStudioService.cs
@@ -371,7 +371,7 @@ public class VisualStudioService : IVisualStudioService
         return true;
     }
 
-    public async Task<bool> ReplaceTextAsync(string oldText, string newText)
+    public async Task<int> ReplaceTextAsync(string oldText, string newText)
     {
         await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
         var dte = await GetDteAsync();
@@ -379,27 +379,32 @@ public class VisualStudioService : IVisualStudioService
         var doc = dte.ActiveDocument;
         if (doc == null)
         {
-            return false;
+            return 0;
         }
 
         var textDoc = doc.Object("TextDocument") as TextDocument;
         if (textDoc == null)
         {
-            return false;
+            return 0;
         }
 
-        var editPoint = textDoc.StartPoint.CreateEditPoint();
-        var content = editPoint.GetText(textDoc.EndPoint);
-        var newContent = content.Replace(oldText, newText);
+        var count = 0;
+        var searchPoint = textDoc.StartPoint.CreateEditPoint();
+        EditPoint matchEnd = null;
 
-        if (content != newContent)
+        while (searchPoint.FindPattern(oldText, (int)vsFindOptions.vsFindOptionsMatchCase, ref matchEnd))
         {
-            editPoint.Delete(textDoc.EndPoint);
-            editPoint.Insert(newContent);
-            return true;
+            count++;
+            searchPoint = matchEnd;
         }
 
-        return false;
+        if (count > 0)
+        {
+            TextRanges tags = null;
+            textDoc.ReplacePattern(oldText, newText, (int)vsFindOptions.vsFindOptionsMatchCase, ref tags);
+        }
+
+        return count;
     }
 
     public async Task<bool> GoToLineAsync(int line)


### PR DESCRIPTION
## Summary
- Use `TextDocument.ReplacePattern` instead of deleting the entire file content and reinserting it, which caused an empty-file intermediate state in the undo history
- Count matches with `FindPattern` before replacing, and return the count to the LLM (e.g., "Replaced 3 occurrence(s)")
- Change `ReplaceTextAsync` return type from `bool` to `int` across the full RPC chain

Closes #37