### PR TITLE
fix(tools): enumerate projects recursively through solution folders

### DIFF
--- a/src/CodingWithCalvin.MCPServer/Services/VisualStudioService.cs
+++ b/src/CodingWithCalvin.MCPServer/Services/VisualStudioService.cs
@@ -106,7 +106,32 @@ public class VisualStudioService : IVisualStudioService
 
         foreach (EnvDTE.Project project in dte.Solution.Projects)
         {
-            try
+            CollectProjects(project, projects);
+        }
+
+        return projects;
+    }
+
+    private static void CollectProjects(EnvDTE.Project project, List<ProjectInfo> projects)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+
+        try
+        {
+            if (project.Kind == ProjectKinds.vsProjectKindSolutionFolder)
+            {
+                if (project.ProjectItems != null)
+                {
+                    foreach (ProjectItem item in project.ProjectItems)
+                    {
+                        if (item.SubProject != null)
+                        {
+                            CollectProjects(item.SubProject, projects);
+                        }
+                    }
+                }
+            }
+            else
             {
                 projects.Add(new ProjectInfo
                 {
@@ -115,13 +140,11 @@ public class VisualStudioService : IVisualStudioService
                     Kind = project.Kind
                 });
             }
-            catch (Exception ex)
-            {
-                VsixTelemetry.TrackException(ex);
-            }
         }
-
-        return projects;
+        catch (Exception ex)
+        {
+            VsixTelemetry.TrackException(ex);
+        }
     }
 
     public async Task<List<DocumentInfo>> GetOpenDocumentsAsync()


### PR DESCRIPTION
## Summary
- Fixes `project_list` tool to recursively enumerate projects nested inside solution folders
- Previously, only top-level items were returned from `dte.Solution.Projects`, so projects grouped in solution folders were missing
- Adds a `CollectProjects` helper that detects solution folders by their `ProjectKind` GUID and walks their `ProjectItems` to find nested projects

Closes #44

## Test plan
- [ ] Open a solution with projects grouped in solution folders
- [ ] Run `project_list` and verify all nested projects are returned
- [ ] Open a flat solution (no folders) and verify `project_list` still works correctly
- [ ] Open a solution with deeply nested folders (folders within folders) and verify all projects are found