### PR TITLE
feat(debugger): add startup project tools and project-specific debug

### DIFF
--- a/src/CodingWithCalvin.MCPServer.Server/RpcClient.cs
+++ b/src/CodingWithCalvin.MCPServer.Server/RpcClient.cs
@@ -137,7 +137,10 @@ public class RpcClient : IVisualStudioRpc, IServerRpc, IDisposable
         => Proxy.FindReferencesAsync(path, line, column, maxResults);
 
     public Task<DebuggerStatus> GetDebuggerStatusAsync() => Proxy.GetDebuggerStatusAsync();
+    public Task<string?> GetStartupProjectAsync() => Proxy.GetStartupProjectAsync();
+    public Task<bool> SetStartupProjectAsync(string projectName) => Proxy.SetStartupProjectAsync(projectName);
     public Task<bool> DebugLaunchAsync() => Proxy.DebugLaunchAsync();
+    public Task<bool> DebugLaunchProjectAsync(string projectName, bool noDebug) => Proxy.DebugLaunchProjectAsync(projectName, noDebug);
     public Task<bool> DebugLaunchWithoutDebuggingAsync() => Proxy.DebugLaunchWithoutDebuggingAsync();
     public Task<bool> DebugContinueAsync() => Proxy.DebugContinueAsync();
     public Task<bool> DebugBreakAsync() => Proxy.DebugBreakAsync();

--- a/src/CodingWithCalvin.MCPServer.Server/Tools/DebuggerTools.cs
+++ b/src/CodingWithCalvin.MCPServer.Server/Tools/DebuggerTools.cs
@@ -26,19 +26,41 @@ public class DebuggerTools
     }
 
     [McpServerTool(Name = "debugger_launch", Destructive = false)]
-    [Description("Start debugging the current startup project (equivalent to F5). A solution must be open with a valid startup project configured. Use debugger_status to check the resulting state.")]
-    public async Task<string> DebugLaunchAsync()
+    [Description("Start debugging a project (equivalent to F5). If projectName is specified, launches that specific project without changing the startup project. Otherwise debugs the current startup project. A solution must be open. Use debugger_status to check the resulting state.")]
+    public async Task<string> DebugLaunchAsync(
+        [Description("Optional: The display name of the project to debug (e.g., 'MyProject'). Launches this project directly without changing the startup project. Use project_list to see available project names.")] string? projectName = null)
     {
-        var success = await _rpcClient.DebugLaunchAsync();
-        return success ? "Debugging started" : "Failed to start debugging (is a solution open with a startup project configured?)";
+        if (projectName != null)
+        {
+            var success = await _rpcClient.DebugLaunchProjectAsync(projectName, noDebug: false);
+            return success
+                ? $"Debugging started for project: {projectName}"
+                : $"Failed to start debugging for project '{projectName}'. Use project_list to verify the project name.";
+        }
+        else
+        {
+            var success = await _rpcClient.DebugLaunchAsync();
+            return success ? "Debugging started" : "Failed to start debugging (is a solution open with a startup project configured?)";
+        }
     }
 
     [McpServerTool(Name = "debugger_launch_without_debugging", Destructive = false)]
-    [Description("Start the current startup project without the debugger attached (equivalent to Ctrl+F5). The application runs normally without breakpoints or stepping. A solution must be open with a valid startup project configured.")]
-    public async Task<string> DebugLaunchWithoutDebuggingAsync()
+    [Description("Start a project without the debugger attached (equivalent to Ctrl+F5). If projectName is specified, launches that specific project without changing the startup project. Otherwise runs the current startup project. The application runs normally without breakpoints or stepping. A solution must be open.")]
+    public async Task<string> DebugLaunchWithoutDebuggingAsync(
+        [Description("Optional: The display name of the project to run (e.g., 'MyProject'). Launches this project directly without changing the startup project. Use project_list to see available project names.")] string? projectName = null)
     {
-        var success = await _rpcClient.DebugLaunchWithoutDebuggingAsync();
-        return success ? "Started without debugging" : "Failed to start without debugging (is a solution open with a startup project configured?)";
+        if (projectName != null)
+        {
+            var success = await _rpcClient.DebugLaunchProjectAsync(projectName, noDebug: true);
+            return success
+                ? $"Started without debugging for project: {projectName}"
+                : $"Failed to start without debugging for project '{projectName}'. Use project_list to verify the project name.";
+        }
+        else
+        {
+            var success = await _rpcClient.DebugLaunchWithoutDebuggingAsync();
+            return success ? "Started without debugging" : "Failed to start without debugging (is a solution open with a startup project configured?)";
+        }
     }
 
     [McpServerTool(Name = "debugger_continue", Destructive = false)]

--- a/src/CodingWithCalvin.MCPServer.Server/Tools/SolutionTools.cs
+++ b/src/CodingWithCalvin.MCPServer.Server/Tools/SolutionTools.cs
@@ -61,6 +61,23 @@ public class SolutionTools
         return JsonSerializer.Serialize(projects, _jsonOptions);
     }
 
+    [McpServerTool(Name = "startup_project_get", ReadOnly = true)]
+    [Description("Get the current startup project name. Returns the project that will be launched when debugging starts.")]
+    public async Task<string> GetStartupProjectAsync()
+    {
+        var startupProject = await _rpcClient.GetStartupProjectAsync();
+        return startupProject ?? "No startup project is set";
+    }
+
+    [McpServerTool(Name = "startup_project_set", Destructive = false)]
+    [Description("Set the startup project for debugging. Use project_list to get available project names.")]
+    public async Task<string> SetStartupProjectAsync(
+        [Description("The display name of the project to set as the startup project (e.g., 'MyProject'). Use project_list to see available project names.")] string name)
+    {
+        var success = await _rpcClient.SetStartupProjectAsync(name);
+        return success ? $"Startup project set to: {name}" : $"Failed to set startup project: {name}";
+    }
+
     [McpServerTool(Name = "project_info", ReadOnly = true)]
     [Description("Get detailed information about a specific project by its display name.")]
     public async Task<string> GetProjectInfoAsync(

--- a/src/CodingWithCalvin.MCPServer.Shared/RpcContracts.cs
+++ b/src/CodingWithCalvin.MCPServer.Shared/RpcContracts.cs
@@ -42,7 +42,10 @@ public interface IVisualStudioRpc
     Task<ReferencesResult> FindReferencesAsync(string path, int line, int column, int maxResults = 100);
 
     Task<DebuggerStatus> GetDebuggerStatusAsync();
+    Task<string?> GetStartupProjectAsync();
+    Task<bool> SetStartupProjectAsync(string projectName);
     Task<bool> DebugLaunchAsync();
+    Task<bool> DebugLaunchProjectAsync(string projectName, bool noDebug);
     Task<bool> DebugLaunchWithoutDebuggingAsync();
     Task<bool> DebugContinueAsync();
     Task<bool> DebugBreakAsync();

--- a/src/CodingWithCalvin.MCPServer/Services/IVisualStudioService.cs
+++ b/src/CodingWithCalvin.MCPServer/Services/IVisualStudioService.cs
@@ -38,7 +38,10 @@ public interface IVisualStudioService
     Task<ReferencesResult> FindReferencesAsync(string path, int line, int column, int maxResults = 100);
 
     Task<DebuggerStatus> GetDebuggerStatusAsync();
+    Task<string?> GetStartupProjectAsync();
+    Task<bool> SetStartupProjectAsync(string projectName);
     Task<bool> DebugLaunchAsync();
+    Task<bool> DebugLaunchProjectAsync(string projectName, bool noDebug);
     Task<bool> DebugLaunchWithoutDebuggingAsync();
     Task<bool> DebugContinueAsync();
     Task<bool> DebugBreakAsync();

--- a/src/CodingWithCalvin.MCPServer/Services/RpcServer.cs
+++ b/src/CodingWithCalvin.MCPServer/Services/RpcServer.cs
@@ -195,7 +195,10 @@ public class RpcServer : IRpcServer, IVisualStudioRpc
         => _vsService.FindReferencesAsync(path, line, column, maxResults);
 
     public Task<DebuggerStatus> GetDebuggerStatusAsync() => _vsService.GetDebuggerStatusAsync();
+    public Task<string?> GetStartupProjectAsync() => _vsService.GetStartupProjectAsync();
+    public Task<bool> SetStartupProjectAsync(string projectName) => _vsService.SetStartupProjectAsync(projectName);
     public Task<bool> DebugLaunchAsync() => _vsService.DebugLaunchAsync();
+    public Task<bool> DebugLaunchProjectAsync(string projectName, bool noDebug) => _vsService.DebugLaunchProjectAsync(projectName, noDebug);
     public Task<bool> DebugLaunchWithoutDebuggingAsync() => _vsService.DebugLaunchWithoutDebuggingAsync();
     public Task<bool> DebugContinueAsync() => _vsService.DebugContinueAsync();
     public Task<bool> DebugBreakAsync() => _vsService.DebugBreakAsync();

--- a/src/CodingWithCalvin.MCPServer/Services/VisualStudioService.cs
+++ b/src/CodingWithCalvin.MCPServer/Services/VisualStudioService.cs
@@ -1144,6 +1144,157 @@ public class VisualStudioService : IVisualStudioService
         return status;
     }
 
+    public async Task<string?> GetStartupProjectAsync()
+    {
+        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+        var dte = await GetDteAsync();
+
+        try
+        {
+            if (dte.Solution?.SolutionBuild?.StartupProjects is Array startupProjects && startupProjects.Length > 0)
+            {
+                return startupProjects.GetValue(0) as string;
+            }
+
+            return null;
+        }
+        catch (Exception ex)
+        {
+            VsixTelemetry.TrackException(ex);
+            return null;
+        }
+    }
+
+    public async Task<bool> SetStartupProjectAsync(string projectName)
+    {
+        using var activity = VsixTelemetry.Tracer.StartActivity("SetStartupProject");
+
+        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+        var dte = await GetDteAsync();
+
+        try
+        {
+            dte.Solution.SolutionBuild.StartupProjects = projectName;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            activity?.RecordException(ex);
+            return false;
+        }
+    }
+
+    public async Task<bool> DebugLaunchProjectAsync(string projectName, bool noDebug)
+    {
+        using var activity = VsixTelemetry.Tracer.StartActivity("DebugLaunchProject");
+
+        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+        var dte = await GetDteAsync();
+
+        try
+        {
+            EnvDTE.Project? targetProject = null;
+
+            foreach (EnvDTE.Project project in dte.Solution.Projects)
+            {
+                targetProject = FindProjectByName(project, projectName);
+                if (targetProject != null)
+                {
+                    break;
+                }
+            }
+
+            if (targetProject == null)
+            {
+                return false;
+            }
+
+            var solution = ServiceProvider.GetService(typeof(SVsSolution)) as IVsSolution;
+            if (solution == null)
+            {
+                return false;
+            }
+
+            ErrorHandler.ThrowOnFailure(
+                solution.GetProjectOfUniqueName(targetProject.UniqueName, out var hierarchy));
+
+            if (hierarchy is not IVsGetCfgProvider getCfgProvider)
+            {
+                return false;
+            }
+
+            ErrorHandler.ThrowOnFailure(getCfgProvider.GetCfgProvider(out var cfgProvider));
+
+            if (cfgProvider is not IVsCfgProvider2 cfgProvider2)
+            {
+                return false;
+            }
+
+            var configName = targetProject.ConfigurationManager.ActiveConfiguration.ConfigurationName;
+            var platformName = targetProject.ConfigurationManager.ActiveConfiguration.PlatformName;
+
+            ErrorHandler.ThrowOnFailure(
+                cfgProvider2.GetCfgOfName(configName, platformName, out var cfg));
+
+            if (cfg is not IVsDebuggableProjectCfg debuggableProjectCfg)
+            {
+                return false;
+            }
+
+            var launchFlags = noDebug
+                ? (uint)__VSDBGLAUNCHFLAGS.DBGLAUNCH_NoDebug
+                : 0u;
+
+            ErrorHandler.ThrowOnFailure(debuggableProjectCfg.DebugLaunch(launchFlags));
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            activity?.RecordException(ex);
+            return false;
+        }
+    }
+
+    private static EnvDTE.Project? FindProjectByName(EnvDTE.Project project, string name)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+
+        try
+        {
+            if (project.Kind == ProjectKinds.vsProjectKindSolutionFolder)
+            {
+                if (project.ProjectItems != null)
+                {
+                    foreach (ProjectItem item in project.ProjectItems)
+                    {
+                        if (item.SubProject != null)
+                        {
+                            var found = FindProjectByName(item.SubProject, name);
+                            if (found != null)
+                            {
+                                return found;
+                            }
+                        }
+                    }
+                }
+
+                return null;
+            }
+
+            return string.Equals(project.Name, name, StringComparison.OrdinalIgnoreCase)
+                ? project
+                : null;
+        }
+        catch (Exception ex)
+        {
+            VsixTelemetry.TrackException(ex);
+            return null;
+        }
+    }
+
     public async Task<bool> DebugLaunchAsync()
     {
         using var activity = VsixTelemetry.Tracer.StartActivity("DebugLaunch");


### PR DESCRIPTION
## Summary
- Adds `startup_project_get` and `startup_project_set` MCP tools for managing the VS startup project
- Adds optional `projectName` parameter to `debugger_launch` and `debugger_launch_without_debugging` tools
- When `projectName` is specified, launches the project directly via `IVsDebuggableProjectCfg.DebugLaunch()` without changing the startup project (same behavior as right-click > Debug > Start New Instance in VS)
- Includes `FindProjectByName` helper that recursively searches through solution folders

Closes #45

## Test plan
- [ ] Use `startup_project_get` to verify it returns the current startup project
- [ ] Use `startup_project_set` to change the startup project and verify it takes effect
- [ ] Use `debugger_launch` without `projectName` — should behave as before (F5)
- [ ] Use `debugger_launch` with `projectName` — should launch that specific project without changing the startup project
- [ ] Use `debugger_launch_without_debugging` with `projectName` — should run without debugger attached
- [ ] Verify startup project is unchanged after using `projectName` parameter
- [ ] Test with projects nested in solution folders