### PR TITLE
feat(debugger): add expression evaluation and variable editing tools

### DIFF
--- a/src/CodingWithCalvin.MCPServer.Server/RpcClient.cs
+++ b/src/CodingWithCalvin.MCPServer.Server/RpcClient.cs
@@ -153,6 +153,8 @@ public class RpcClient : IVisualStudioRpc, IServerRpc, IDisposable
     public Task<bool> DebugRemoveBreakpointAsync(string file, int line) => Proxy.DebugRemoveBreakpointAsync(file, line);
     public Task<List<BreakpointInfo>> DebugGetBreakpointsAsync() => Proxy.DebugGetBreakpointsAsync();
     public Task<List<Shared.Models.LocalVariableInfo>> DebugGetLocalsAsync() => Proxy.DebugGetLocalsAsync();
+    public Task<ExpressionResult> DebugEvaluateExpressionAsync(string expression) => Proxy.DebugEvaluateExpressionAsync(expression);
+    public Task<bool> DebugSetVariableValueAsync(string variableName, string value) => Proxy.DebugSetVariableValueAsync(variableName, value);
     public Task<List<CallStackFrameInfo>> DebugGetCallStackAsync() => Proxy.DebugGetCallStackAsync();
 
     public Task<ErrorListResult> GetErrorListAsync(string? severity = null, int maxResults = 100)

--- a/src/CodingWithCalvin.MCPServer.Server/Tools/DebuggerTools.cs
+++ b/src/CodingWithCalvin.MCPServer.Server/Tools/DebuggerTools.cs
@@ -143,6 +143,27 @@ public class DebuggerTools
         return JsonSerializer.Serialize(locals, _jsonOptions);
     }
 
+    [McpServerTool(Name = "debugger_evaluate", ReadOnly = true)]
+    [Description("Evaluate an expression in the current debug context (like the Immediate Window). Only works when the debugger is in Break mode. Returns the expression, its value, type, and whether the value is valid.")]
+    public async Task<string> DebugEvaluateExpressionAsync(
+        [Description("The expression to evaluate (e.g., 'myVariable', 'list.Count', 'x + y', 'myObject.ToString()')")] string expression)
+    {
+        var result = await _rpcClient.DebugEvaluateExpressionAsync(expression);
+        return JsonSerializer.Serialize(result, _jsonOptions);
+    }
+
+    [McpServerTool(Name = "debugger_set_variable", Destructive = true)]
+    [Description("Set the value of a local variable in the current stack frame. Only works when the debugger is in Break mode. The variable must exist in the current scope.")]
+    public async Task<string> DebugSetVariableValueAsync(
+        [Description("The name of the local variable to modify (e.g., 'count', 'name'). Use debugger_get_locals to see available variables.")] string variableName,
+        [Description("The new value to assign (e.g., '42', '\"hello\"', 'true'). Must be a valid expression for the variable's type.")] string value)
+    {
+        var success = await _rpcClient.DebugSetVariableValueAsync(variableName, value);
+        return success
+            ? $"Variable '{variableName}' set to: {value}"
+            : $"Failed to set variable '{variableName}'. Ensure the debugger is in Break mode, the variable exists in the current scope, and the value is valid for its type.";
+    }
+
     [McpServerTool(Name = "debugger_get_callstack", ReadOnly = true)]
     [Description("Get the call stack of the current thread. Only works when the debugger is in Break mode. Returns depth, function name, file name, line number, module, language, and return type for each frame.")]
     public async Task<string> DebugGetCallStackAsync()

--- a/src/CodingWithCalvin.MCPServer.Shared/Models/DebuggerModels.cs
+++ b/src/CodingWithCalvin.MCPServer.Shared/Models/DebuggerModels.cs
@@ -30,6 +30,14 @@ public class LocalVariableInfo
     public bool IsValidValue { get; set; }
 }
 
+public class ExpressionResult
+{
+    public string Expression { get; set; } = string.Empty;
+    public string Value { get; set; } = string.Empty;
+    public string Type { get; set; } = string.Empty;
+    public bool IsValidValue { get; set; }
+}
+
 public class CallStackFrameInfo
 {
     public int Depth { get; set; }

--- a/src/CodingWithCalvin.MCPServer.Shared/RpcContracts.cs
+++ b/src/CodingWithCalvin.MCPServer.Shared/RpcContracts.cs
@@ -58,6 +58,8 @@ public interface IVisualStudioRpc
     Task<bool> DebugRemoveBreakpointAsync(string file, int line);
     Task<List<BreakpointInfo>> DebugGetBreakpointsAsync();
     Task<List<LocalVariableInfo>> DebugGetLocalsAsync();
+    Task<ExpressionResult> DebugEvaluateExpressionAsync(string expression);
+    Task<bool> DebugSetVariableValueAsync(string variableName, string value);
     Task<List<CallStackFrameInfo>> DebugGetCallStackAsync();
 
     // Diagnostics tools

--- a/src/CodingWithCalvin.MCPServer/Services/IVisualStudioService.cs
+++ b/src/CodingWithCalvin.MCPServer/Services/IVisualStudioService.cs
@@ -54,6 +54,8 @@ public interface IVisualStudioService
     Task<bool> DebugRemoveBreakpointAsync(string file, int line);
     Task<List<BreakpointInfo>> DebugGetBreakpointsAsync();
     Task<List<LocalVariableInfo>> DebugGetLocalsAsync();
+    Task<ExpressionResult> DebugEvaluateExpressionAsync(string expression);
+    Task<bool> DebugSetVariableValueAsync(string variableName, string value);
     Task<List<CallStackFrameInfo>> DebugGetCallStackAsync();
 
     Task<ErrorListResult> GetErrorListAsync(string? severity = null, int maxResults = 100);

--- a/src/CodingWithCalvin.MCPServer/Services/RpcServer.cs
+++ b/src/CodingWithCalvin.MCPServer/Services/RpcServer.cs
@@ -211,6 +211,8 @@ public class RpcServer : IRpcServer, IVisualStudioRpc
     public Task<bool> DebugRemoveBreakpointAsync(string file, int line) => _vsService.DebugRemoveBreakpointAsync(file, line);
     public Task<List<BreakpointInfo>> DebugGetBreakpointsAsync() => _vsService.DebugGetBreakpointsAsync();
     public Task<List<LocalVariableInfo>> DebugGetLocalsAsync() => _vsService.DebugGetLocalsAsync();
+    public Task<ExpressionResult> DebugEvaluateExpressionAsync(string expression) => _vsService.DebugEvaluateExpressionAsync(expression);
+    public Task<bool> DebugSetVariableValueAsync(string variableName, string value) => _vsService.DebugSetVariableValueAsync(variableName, value);
     public Task<List<CallStackFrameInfo>> DebugGetCallStackAsync() => _vsService.DebugGetCallStackAsync();
 
     public Task<ErrorListResult> GetErrorListAsync(string? severity = null, int maxResults = 100)

--- a/src/CodingWithCalvin.MCPServer/Services/VisualStudioService.cs
+++ b/src/CodingWithCalvin.MCPServer/Services/VisualStudioService.cs
@@ -1633,6 +1633,85 @@ public class VisualStudioService : IVisualStudioService
         return results;
     }
 
+    public async Task<ExpressionResult> DebugEvaluateExpressionAsync(string expression)
+    {
+        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+        var dte = await GetDteAsync();
+        var debugger = (Debugger2)dte.Debugger;
+
+        if (debugger.CurrentMode != dbgDebugMode.dbgBreakMode)
+        {
+            return new ExpressionResult
+            {
+                Expression = expression,
+                IsValidValue = false,
+                Value = "Debugger is not in Break mode"
+            };
+        }
+
+        try
+        {
+            var expr = debugger.GetExpression(expression, false, 1000);
+            return new ExpressionResult
+            {
+                Expression = expression,
+                Value = expr.Value ?? string.Empty,
+                Type = expr.Type ?? string.Empty,
+                IsValidValue = expr.IsValidValue
+            };
+        }
+        catch (Exception ex)
+        {
+            VsixTelemetry.TrackException(ex);
+            return new ExpressionResult
+            {
+                Expression = expression,
+                IsValidValue = false,
+                Value = ex.Message
+            };
+        }
+    }
+
+    public async Task<bool> DebugSetVariableValueAsync(string variableName, string value)
+    {
+        using var activity = VsixTelemetry.Tracer.StartActivity("DebugSetVariableValue");
+
+        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+        var dte = await GetDteAsync();
+        var debugger = (Debugger2)dte.Debugger;
+
+        if (debugger.CurrentMode != dbgDebugMode.dbgBreakMode)
+        {
+            return false;
+        }
+
+        try
+        {
+            var frame = debugger.CurrentStackFrame;
+            if (frame == null)
+            {
+                return false;
+            }
+
+            foreach (Expression local in frame.Locals)
+            {
+                if (local.Name == variableName)
+                {
+                    local.Value = value;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+        catch (Exception ex)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            activity?.RecordException(ex);
+            return false;
+        }
+    }
+
     public async Task<List<CallStackFrameInfo>> DebugGetCallStackAsync()
     {
         await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();


### PR DESCRIPTION
## Summary
- Adds `debugger_evaluate` tool for evaluating arbitrary expressions in the current debug context (like the Immediate Window), using `Debugger2.GetExpression()`
- Adds `debugger_set_variable` tool for modifying local variable values during a debug session, using `Expression.Value` setter
- Adds `ExpressionResult` model for returning evaluation results with expression, value, type, and validity
- Both tools require the debugger to be in Break mode

Closes #47

## Test plan
- [ ] Break at a breakpoint, use `debugger_evaluate` with a simple variable name — should return its value and type
- [ ] Use `debugger_evaluate` with a complex expression (e.g., `list.Count`, `x + y`) — should evaluate correctly
- [ ] Use `debugger_evaluate` with an invalid expression — should return `IsValidValue: false`
- [ ] Call `debugger_evaluate` when not in Break mode — should return appropriate message
- [ ] Use `debugger_set_variable` to change a local variable's value, then `debugger_get_locals` to verify the change
- [ ] Use `debugger_set_variable` with a non-existent variable name — should return failure
- [ ] Use `debugger_set_variable` with an invalid value for the type — should return failure