### PR TITLE
docs(readme): add new tools and alphabetize tool lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,51 +44,53 @@
 
 | Tool | Description |
 |------|-------------|
+| `project_info` | Get detailed project information |
+| `project_list` | List all projects in the solution |
+| `solution_close` | Close the current solution |
 | `solution_info` | Get information about the current solution |
 | `solution_open` | Open a solution file |
-| `solution_close` | Close the current solution |
-| `project_list` | List all projects in the solution |
-| `project_info` | Get detailed project information |
+| `startup_project_get` | Get the current startup project |
+| `startup_project_set` | Set the startup project for debugging |
 
 ### 📝 Document Tools
 
 | Tool | Description |
 |------|-------------|
-| `document_list` | List all open documents |
 | `document_active` | Get the active document |
-| `document_open` | Open a file in the editor |
 | `document_close` | Close a document |
+| `document_list` | List all open documents |
+| `document_open` | Open a file in the editor |
 | `document_read` | Read document contents |
-| `document_write` | Write to a document |
 | `document_save` | Saves an open document |
+| `document_write` | Write to a document |
 
 ### ✏️ Editor Tools
 
 | Tool | Description |
 |------|-------------|
-| `selection_get` | Get the current text selection |
-| `selection_set` | Set the selection range |
+| `editor_find` | Search within documents |
+| `editor_goto_line` | Navigate to a specific line |
 | `editor_insert` | Insert text at cursor position |
 | `editor_replace` | Find and replace text |
-| `editor_goto_line` | Navigate to a specific line |
-| `editor_find` | Search within documents |
+| `selection_get` | Get the current text selection |
+| `selection_set` | Set the selection range |
 
 ### 🔨 Build Tools
 
 | Tool | Description |
 |------|-------------|
-| `build_solution` | Build the entire solution |
-| `build_project` | Build a specific project |
-| `clean_solution` | Clean the solution |
 | `build_cancel` | Cancel a running build |
+| `build_project` | Build a specific project |
+| `build_solution` | Build the entire solution |
 | `build_status` | Get current build status |
+| `clean_solution` | Clean the solution |
 
 ### 🧭 Navigation Tools
 
 | Tool | Description |
 |------|-------------|
-| `goto_definition` | Navigate to the definition of a symbol |
 | `find_references` | Find all references to a symbol |
+| `goto_definition` | Navigate to the definition of a symbol |
 | `symbol_document` | Get all symbols defined in a document |
 | `symbol_workspace` | Search for symbols across the solution |
 
@@ -96,29 +98,31 @@
 
 | Tool | Description |
 |------|-------------|
-| `debugger_status` | Get current debugger state |
-| `debugger_launch` | Start debugging (F5) |
-| `debugger_launch_without_debugging` | Start without debugger (Ctrl+F5) |
-| `debugger_continue` | Continue execution (F5) |
+| `debugger_add_breakpoint` | Add a breakpoint at a file and line |
 | `debugger_break` | Pause execution (Ctrl+Alt+Break) |
-| `debugger_stop` | Stop debugging (Shift+F5) |
-| `debugger_step_over` | Step over (F10) |
+| `debugger_continue` | Continue execution (F5) |
+| `debugger_evaluate` | Evaluate an expression in the current debug context |
+| `debugger_get_callstack` | Get the call stack |
+| `debugger_get_locals` | Get local variables in current frame |
+| `debugger_launch` | Start debugging (F5), optionally for a specific project |
+| `debugger_launch_without_debugging` | Start without debugger (Ctrl+F5), optionally for a specific project |
+| `debugger_list_breakpoints` | List all breakpoints |
+| `debugger_remove_breakpoint` | Remove a breakpoint |
+| `debugger_set_variable` | Set the value of a local variable |
+| `debugger_status` | Get current debugger state |
 | `debugger_step_into` | Step into (F11) |
 | `debugger_step_out` | Step out (Shift+F11) |
-| `debugger_add_breakpoint` | Add a breakpoint at a file and line |
-| `debugger_remove_breakpoint` | Remove a breakpoint |
-| `debugger_list_breakpoints` | List all breakpoints |
-| `debugger_get_locals` | Get local variables in current frame |
-| `debugger_get_callstack` | Get the call stack |
+| `debugger_step_over` | Step over (F10) |
+| `debugger_stop` | Stop debugging (Shift+F5) |
 
 ### 🔍 Diagnostics Tools
 
 | Tool | Description |
 |------|-------------|
 | `errors_list` | Read build errors, warnings, and messages from the Error List |
+| `output_list_panes` | List all available Output window panes |
 | `output_read` | Read content from an Output window pane |
 | `output_write` | Write a message to an Output window pane |
-| `output_list_panes` | List all available Output window panes |
 
 ## 🛠️ Installation
 


### PR DESCRIPTION
## Summary
- Adds missing tools to README: `startup_project_get`, `startup_project_set`, `debugger_evaluate`, `debugger_set_variable`
- Updates `debugger_launch` and `debugger_launch_without_debugging` descriptions to note optional project parameter
- Alphabetizes all tool tables in their respective sections

## Test plan
- [ ] Verify all tools in the codebase are listed in the README
- [ ] Verify all tool tables are alphabetically sorted