### PR TITLE
ci(build): skip build on readme-only changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'src/**'
+      - '.github/workflows/build.yml'
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- Add `paths` filter to `push` trigger so README-only commits (from the scheduled contributors workflow) no longer fire a build on main

## Test plan
- [ ] Confirm next scheduled contributors run does not trigger Build
- [ ] Confirm a `src/**` push still triggers Build
- [ ] Confirm PR sync still triggers Build