### PR TITLE
feat(tools): add document_cleanup tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
 | Tool | Description |
 |------|-------------|
 | `document_active` | Get the active document |
+| `document_cleanup` | Run code cleanup on a document |
 | `document_close` | Close a document |
 | `document_list` | List all open documents |
 | `document_open` | Open a file in the editor |

--- a/src/CodingWithCalvin.MCPServer.Server/RpcClient.cs
+++ b/src/CodingWithCalvin.MCPServer.Server/RpcClient.cs
@@ -112,6 +112,7 @@ public class RpcClient : IVisualStudioRpc, IServerRpc, IDisposable
     public Task<bool> OpenDocumentAsync(string path) => Proxy.OpenDocumentAsync(path);
     public Task<bool> CloseDocumentAsync(string path, bool save) => Proxy.CloseDocumentAsync(path, save);
     public Task<bool> SaveDocumentAsync(string path) => Proxy.SaveDocumentAsync(path);
+    public Task<bool> RunCodeCleanupAsync(string path) => Proxy.RunCodeCleanupAsync(path);
     public Task<string?> ReadDocumentAsync(string path) => Proxy.ReadDocumentAsync(path);
     public Task<bool> WriteDocumentAsync(string path, string content) => Proxy.WriteDocumentAsync(path, content);
     public Task<SelectionInfo?> GetSelectionAsync() => Proxy.GetSelectionAsync();

--- a/src/CodingWithCalvin.MCPServer.Server/Tools/DocumentTools.cs
+++ b/src/CodingWithCalvin.MCPServer.Server/Tools/DocumentTools.cs
@@ -72,6 +72,15 @@ public class DocumentTools
         return success ? $"Saved: {path}" : $"Document not found or failed to save: {path}";
     }
 
+    [McpServerTool(Name = "document_cleanup", Destructive = true, Idempotent = true)]
+    [Description("Run code cleanup on an open document in Visual Studio. The document must already be open in VS. Activates the document and executes the 'Edit.RunCodeCleanupOnFile' command.")]
+    public async Task<string> RunCodeCleanupAsync(
+        [Description("The full absolute path to the document. Must be open in VS. Get the path from document_list. Supports forward slashes (/) or backslashes (\\).")] string path)
+    {
+        var success = await _rpcClient.RunCodeCleanupAsync(path);
+        return success ? $"Code cleanup completed: {path}" : $"Document not found or code cleanup failed: {path}";
+    }
+
     [McpServerTool(Name = "document_read", ReadOnly = true)]
     [Description("Read the contents of a document. If the document is open in VS, reads the current editor buffer (including unsaved changes); otherwise reads from disk.")]
     public async Task<string> ReadDocumentAsync(

--- a/src/CodingWithCalvin.MCPServer.Server/Tools/DocumentTools.cs
+++ b/src/CodingWithCalvin.MCPServer.Server/Tools/DocumentTools.cs
@@ -73,7 +73,7 @@ public class DocumentTools
     }
 
     [McpServerTool(Name = "document_cleanup", Destructive = true, Idempotent = true)]
-    [Description("Run code cleanup on an open document in Visual Studio. The document must already be open in VS. Activates the document and executes the 'Edit.RunCodeCleanupOnFile' command.")]
+    [Description("Run code cleanup on an open document in Visual Studio. The document must already be open in VS. Activates the document and executes the 'EditorContextMenus.FileHealthIndicator.RunDefaultCodeCleanup' command.")]
     public async Task<string> RunCodeCleanupAsync(
         [Description("The full absolute path to the document. Must be open in VS. Get the path from document_list. Supports forward slashes (/) or backslashes (\\).")] string path)
     {

--- a/src/CodingWithCalvin.MCPServer.Shared/RpcContracts.cs
+++ b/src/CodingWithCalvin.MCPServer.Shared/RpcContracts.cs
@@ -20,6 +20,7 @@ public interface IVisualStudioRpc
     Task<bool> OpenDocumentAsync(string path);
     Task<bool> CloseDocumentAsync(string path, bool save);
     Task<bool> SaveDocumentAsync(string path);
+    Task<bool> RunCodeCleanupAsync(string path);
     Task<string?> ReadDocumentAsync(string path);
     Task<bool> WriteDocumentAsync(string path, string content);
     Task<SelectionInfo?> GetSelectionAsync();

--- a/src/CodingWithCalvin.MCPServer/Services/IVisualStudioService.cs
+++ b/src/CodingWithCalvin.MCPServer/Services/IVisualStudioService.cs
@@ -16,6 +16,7 @@ public interface IVisualStudioService
     Task<bool> OpenDocumentAsync(string path);
     Task<bool> CloseDocumentAsync(string path, bool save = true);
     Task<bool> SaveDocumentAsync(string path);
+    Task<bool> RunCodeCleanupAsync(string path);
     Task<string?> ReadDocumentAsync(string path);
     Task<bool> WriteDocumentAsync(string path, string content);
     Task<SelectionInfo?> GetSelectionAsync();

--- a/src/CodingWithCalvin.MCPServer/Services/RpcServer.cs
+++ b/src/CodingWithCalvin.MCPServer/Services/RpcServer.cs
@@ -170,6 +170,7 @@ public class RpcServer : IRpcServer, IVisualStudioRpc
     public Task<bool> OpenDocumentAsync(string path) => _vsService.OpenDocumentAsync(path);
     public Task<bool> CloseDocumentAsync(string path, bool save) => _vsService.CloseDocumentAsync(path, save);
     public Task<bool> SaveDocumentAsync(string path) => _vsService.SaveDocumentAsync(path);
+    public Task<bool> RunCodeCleanupAsync(string path) => _vsService.RunCodeCleanupAsync(path);
     public Task<string?> ReadDocumentAsync(string path) => _vsService.ReadDocumentAsync(path);
     public Task<bool> WriteDocumentAsync(string path, string content) => _vsService.WriteDocumentAsync(path, content);
     public Task<SelectionInfo?> GetSelectionAsync() => _vsService.GetSelectionAsync();

--- a/src/CodingWithCalvin.MCPServer/Services/VisualStudioService.cs
+++ b/src/CodingWithCalvin.MCPServer/Services/VisualStudioService.cs
@@ -260,6 +260,31 @@ public class VisualStudioService : IVisualStudioService
         return false;
     }
 
+    public async Task<bool> RunCodeCleanupAsync(string path)
+    {
+        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+        var dte = await GetDteAsync();
+
+        foreach (Document doc in dte.Documents)
+        {
+            try
+            {
+                if (PathsEqual(doc.FullName, path))
+                {
+                    doc.Activate();
+                    dte.ExecuteCommand("EditorContextMenus.FileHealthIndicator.RunDefaultCodeCleanup");
+                    return true;
+                }
+            }
+            catch (Exception ex)
+            {
+                VsixTelemetry.TrackException(ex);
+            }
+        }
+
+        return false;
+    }
+
     public async Task<string?> ReadDocumentAsync(string path)
     {
         await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();


### PR DESCRIPTION
## Description

Add missing document cleanup tool for running the code clean up in an active document.

## Tools to Implement
| Tool | Description |
|------|-------------|
| `document_cleanup` | Run the visual studio code cleanup tool on the active document |

## Notes
- Extends existing document tools category
- The internal command name is "EditorContextMenus.FileHealthIndicator.RunDefaultCodeCleanup"

## Type of Change

- [x] `feat` - New feature
- [ ] `fix` - Bug fix
- [ ] `docs` - Documentation only
- [ ] `refactor` - Code change that neither fixes a bug nor adds a feature
- [ ] `test` - Adding or updating tests
- [ ] `chore` - Maintenance tasks
- [ ] `ci` - CI/CD changes

## Related Issues

<!-- Link any related issues using "Closes #123" or "Fixes #123" -->

## Checklist

- [x] My code follows the project's code style
- [x] I have tested my changes locally
- [x] I have updated documentation if needed
- [x] My commits follow the conventional commit format
- [x] This PR has a descriptive title using conventional commit format