### PR TITLE
fix(server): pin MessagePack to remediate GHSA-hv8m-jj95-wg3x

### DIFF
--- a/src/CodingWithCalvin.MCPServer.Server/CodingWithCalvin.MCPServer.Server.csproj
+++ b/src/CodingWithCalvin.MCPServer.Server/CodingWithCalvin.MCPServer.Server.csproj
@@ -18,6 +18,9 @@
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.8.0-preview.1" />
     <PackageReference Include="StreamJsonRpc" Version="2.20.20" />
+    <!-- Pin MessagePack above the transitive 2.5.187 pulled in by StreamJsonRpc to
+         remediate GHSA-hv8m-jj95-wg3x (high severity, NU1903). -->
+    <PackageReference Include="MessagePack" Version="2.5.302" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

CI builds are failing during NuGet restore with `NU1903` (warning-as-error):

> Package `MessagePack` 2.5.187 has a known high severity vulnerability, https://github.com/advisories/GHSA-hv8m-jj95-wg3x

`MessagePack 2.5.187` is pulled in **transitively** by `StreamJsonRpc 2.20.20` in `CodingWithCalvin.MCPServer.Server`. Because the build treats warnings as errors, the advisory blocks every build — including unrelated PRs such as #93.

## Change

Add a direct `PackageReference` to `MessagePack` `2.5.302` (latest patched `2.5.x`, advisory fixed in `2.5.192`) to override the vulnerable transitive version.

## Validation

- `dotnet publish` of the Server project now restores and builds cleanly with no `NU1903` error.