### PR TITLE
fix(build): make build/clean tools non-blocking to match async contract

### DIFF
--- a/src/CodingWithCalvin.MCPServer/Services/VisualStudioService.cs
+++ b/src/CodingWithCalvin.MCPServer/Services/VisualStudioService.cs
@@ -621,7 +621,7 @@ public class VisualStudioService : IVisualStudioService
 
         try
         {
-            dte.Solution.SolutionBuild.Build(true);
+            dte.Solution.SolutionBuild.Build(false);
             return true;
         }
         catch (Exception ex)
@@ -643,7 +643,7 @@ public class VisualStudioService : IVisualStudioService
         {
             var config = dte.Solution.SolutionBuild.ActiveConfiguration.Name;
             var normalizedPath = NormalizePath(projectName);
-            dte.Solution.SolutionBuild.BuildProject(config, normalizedPath, true);
+            dte.Solution.SolutionBuild.BuildProject(config, normalizedPath, false);
             return true;
         }
         catch (Exception ex)
@@ -663,7 +663,7 @@ public class VisualStudioService : IVisualStudioService
 
         try
         {
-            dte.Solution.SolutionBuild.Clean(true);
+            dte.Solution.SolutionBuild.Clean(false);
             return true;
         }
         catch (Exception ex)


### PR DESCRIPTION
## Problem
`build_solution`, `build_project`, and `clean_solution` are documented as asynchronous ("runs asynchronously; use `build_status` to check progress; returns immediately after starting the build"), but they block until the build/clean fully completes.

This shows up in daily real-world use: I drive builds through this MCP on a large Unreal Engine 5 (C++) solution, and `build_solution` consistently returns `The operation timed out.` instead of `Build started`. Because the blocking call also freezes the Visual Studio UI thread for the whole build, `build_status` and `build_cancel` can't run either — so the documented "start build, then poll `build_status`" workflow is impossible on any large solution.

## Root cause
`src/CodingWithCalvin.MCPServer/Services/VisualStudioService.cs` calls the EnvDTE `SolutionBuild` APIs with the wait flag set to `true`, right after `SwitchToMainThreadAsync()`:

```csharp
dte.Solution.SolutionBuild.Build(true);                       // BuildSolutionAsync
dte.Solution.SolutionBuild.BuildProject(config, path, true);  // BuildProjectAsync
dte.Solution.SolutionBuild.Clean(true);                       // CleanSolutionAsync
```

The final boolean is `WaitForBuildToFinish` / `WaitForCleanToFinish`; `true` blocks on the UI thread until the whole operation finishes.

## Fix
Pass `false` so the build/clean is queued and the call returns immediately. This restores the documented async behavior and lets `build_status` observe the `InProgress -> Done` transition as intended.

## Testing
No automated coverage — the repo has no test harness yet (#11); this is a minimal per-call flag flip.
