### PR TITLE
feat(build): allow changing active configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@
 | Tool | Description |
 |------|-------------|
 | `build_cancel` | Cancel a running build |
+| `build_configuration_get` | Get the active and available build configuration/platform pairs |
+| `build_configuration_set` | Change the active build configuration and platform |
 | `build_project` | Build a specific project |
 | `build_solution` | Build the entire solution |
 | `build_status` | Get current build status |

--- a/src/CodingWithCalvin.MCPServer.Server/RpcClient.cs
+++ b/src/CodingWithCalvin.MCPServer.Server/RpcClient.cs
@@ -130,6 +130,9 @@ public class RpcClient : IVisualStudioRpc, IServerRpc, IDisposable
     public Task<bool> CleanSolutionAsync() => Proxy.CleanSolutionAsync();
     public Task<bool> CancelBuildAsync() => Proxy.CancelBuildAsync();
     public Task<BuildStatus> GetBuildStatusAsync() => Proxy.GetBuildStatusAsync();
+    public Task<BuildConfigurationInfo> GetBuildConfigurationAsync() => Proxy.GetBuildConfigurationAsync();
+    public Task<bool> SetBuildConfigurationAsync(string configuration, string platform)
+        => Proxy.SetBuildConfigurationAsync(configuration, platform);
 
     public Task<List<SymbolInfo>> GetDocumentSymbolsAsync(string path) => Proxy.GetDocumentSymbolsAsync(path);
     public Task<WorkspaceSymbolResult> SearchWorkspaceSymbolsAsync(string query, int maxResults = 100)

--- a/src/CodingWithCalvin.MCPServer.Server/Tools/BuildTools.cs
+++ b/src/CodingWithCalvin.MCPServer.Server/Tools/BuildTools.cs
@@ -10,6 +10,8 @@ public class BuildTools
 {
     private const string DebugSessionActiveMessage =
         "A debug session is currently active. Stop debugging first using debugger_stop before building.";
+    private const string ConfigurationDebugSessionActiveMessage =
+        "A debug session is currently active. Stop debugging first using debugger_stop before changing the build configuration.";
 
     private readonly RpcClient _rpcClient;
     private readonly JsonSerializerOptions _jsonOptions;
@@ -80,5 +82,39 @@ public class BuildTools
     {
         var status = await _rpcClient.GetBuildStatusAsync();
         return JsonSerializer.Serialize(status, _jsonOptions);
+    }
+
+    [McpServerTool(Name = "build_configuration_get", ReadOnly = true)]
+    [Description("Get the active solution build configuration and platform, plus every available configuration/platform pair. Use this before build_configuration_set to discover exact values such as 'Release' and 'x64'.")]
+    public async Task<string> GetBuildConfigurationAsync()
+    {
+        var configuration = await _rpcClient.GetBuildConfigurationAsync();
+        return JsonSerializer.Serialize(configuration, _jsonOptions);
+    }
+
+    [McpServerTool(Name = "build_configuration_set", Destructive = false, Idempotent = true)]
+    [Description("Activate an existing solution build configuration and platform in Visual Studio, such as 'Release' and 'x64'. Call build_configuration_get first because only listed pairs are accepted. Cannot change configuration while a build or debug session is active.")]
+    public async Task<string> SetBuildConfigurationAsync(
+        [Description("Solution configuration name, such as 'Debug' or 'Release'.")] string configuration,
+        [Description("Solution platform/architecture, such as 'Any CPU', 'x64', or 'ARM64'.")] string platform)
+    {
+        if (string.IsNullOrWhiteSpace(configuration) || string.IsNullOrWhiteSpace(platform))
+        {
+            return "Configuration and platform are required. Call build_configuration_get for available values.";
+        }
+
+        if (await IsDebuggingActiveAsync())
+        {
+            return ConfigurationDebugSessionActiveMessage;
+        }
+
+        var success = await _rpcClient.SetBuildConfigurationAsync(configuration.Trim(), platform.Trim());
+        if (!success)
+        {
+            return $"Failed to activate build configuration '{configuration}|{platform}'. A build may be running or the pair may not exist. Call build_configuration_get for available values.";
+        }
+
+        var activeConfiguration = await _rpcClient.GetBuildConfigurationAsync();
+        return $"Active build configuration: {activeConfiguration.ActiveConfiguration}|{activeConfiguration.ActivePlatform}";
     }
 }

--- a/src/CodingWithCalvin.MCPServer.Shared/Models/BuildModels.cs
+++ b/src/CodingWithCalvin.MCPServer.Shared/Models/BuildModels.cs
@@ -1,4 +1,19 @@
+using System.Collections.Generic;
+
 namespace CodingWithCalvin.MCPServer.Shared.Models;
+
+public class BuildConfiguration
+{
+    public string Configuration { get; set; } = string.Empty;
+    public string Platform { get; set; } = string.Empty;
+}
+
+public class BuildConfigurationInfo
+{
+    public string ActiveConfiguration { get; set; } = string.Empty;
+    public string ActivePlatform { get; set; } = string.Empty;
+    public List<BuildConfiguration> AvailableConfigurations { get; set; } = new();
+}
 
 public class BuildStatus
 {

--- a/src/CodingWithCalvin.MCPServer.Shared/RpcContracts.cs
+++ b/src/CodingWithCalvin.MCPServer.Shared/RpcContracts.cs
@@ -38,6 +38,8 @@ public interface IVisualStudioRpc
     Task<bool> CleanSolutionAsync();
     Task<bool> CancelBuildAsync();
     Task<BuildStatus> GetBuildStatusAsync();
+    Task<BuildConfigurationInfo> GetBuildConfigurationAsync();
+    Task<bool> SetBuildConfigurationAsync(string configuration, string platform);
 
     Task<List<SymbolInfo>> GetDocumentSymbolsAsync(string path);
     Task<WorkspaceSymbolResult> SearchWorkspaceSymbolsAsync(string query, int maxResults = 100);

--- a/src/CodingWithCalvin.MCPServer.Tests/BuildConfigurationTests.cs
+++ b/src/CodingWithCalvin.MCPServer.Tests/BuildConfigurationTests.cs
@@ -1,0 +1,27 @@
+using CodingWithCalvin.MCPServer.Services;
+using Xunit;
+
+namespace CodingWithCalvin.MCPServer.Tests;
+
+public class BuildConfigurationTests
+{
+    [Theory]
+    [InlineData("Debug", "Any CPU", "debug", "any cpu", true)]
+    [InlineData("Release", "x64", "Debug", "x64", false)]
+    [InlineData("Release", "x64", "Release", "ARM64", false)]
+    public void MatchesBuildConfiguration_RequiresExactConfigurationAndPlatform(
+        string candidateConfiguration,
+        string candidatePlatform,
+        string configuration,
+        string platform,
+        bool expected)
+    {
+        Assert.Equal(
+            expected,
+            VisualStudioService.MatchesBuildConfiguration(
+                candidateConfiguration,
+                candidatePlatform,
+                configuration,
+                platform));
+    }
+}

--- a/src/CodingWithCalvin.MCPServer/Services/IVisualStudioService.cs
+++ b/src/CodingWithCalvin.MCPServer/Services/IVisualStudioService.cs
@@ -34,6 +34,8 @@ public interface IVisualStudioService
     Task<bool> CleanSolutionAsync();
     Task<bool> CancelBuildAsync();
     Task<BuildStatus> GetBuildStatusAsync();
+    Task<BuildConfigurationInfo> GetBuildConfigurationAsync();
+    Task<bool> SetBuildConfigurationAsync(string configuration, string platform);
 
     Task<List<SymbolInfo>> GetDocumentSymbolsAsync(string path);
     Task<WorkspaceSymbolResult> SearchWorkspaceSymbolsAsync(string query, int maxResults = 100);

--- a/src/CodingWithCalvin.MCPServer/Services/RpcServer.cs
+++ b/src/CodingWithCalvin.MCPServer/Services/RpcServer.cs
@@ -239,6 +239,9 @@ public class RpcServer : IRpcServer, IVisualStudioRpc
     public Task<bool> CleanSolutionAsync() => _vsService.CleanSolutionAsync();
     public Task<bool> CancelBuildAsync() => _vsService.CancelBuildAsync();
     public Task<BuildStatus> GetBuildStatusAsync() => _vsService.GetBuildStatusAsync();
+    public Task<BuildConfigurationInfo> GetBuildConfigurationAsync() => _vsService.GetBuildConfigurationAsync();
+    public Task<bool> SetBuildConfigurationAsync(string configuration, string platform)
+        => _vsService.SetBuildConfigurationAsync(configuration, platform);
 
     public Task<List<SymbolInfo>> GetDocumentSymbolsAsync(string path) => _vsService.GetDocumentSymbolsAsync(path);
     public Task<WorkspaceSymbolResult> SearchWorkspaceSymbolsAsync(string query, int maxResults = 100)

--- a/src/CodingWithCalvin.MCPServer/Services/VisualStudioService.cs
+++ b/src/CodingWithCalvin.MCPServer/Services/VisualStudioService.cs
@@ -43,6 +43,14 @@ public class VisualStudioService : IVisualStudioService
         return Path.GetFullPath(path.Replace('/', '\\'));
     }
 
+    internal static bool MatchesBuildConfiguration(
+        string candidateConfiguration,
+        string candidatePlatform,
+        string configuration,
+        string platform) =>
+        string.Equals(candidateConfiguration, configuration, StringComparison.OrdinalIgnoreCase)
+        && string.Equals(candidatePlatform, platform, StringComparison.OrdinalIgnoreCase);
+
     private static string DetectLineEnding(string content)
     {
         if (content.Contains("\r\n")) return "\r\n";
@@ -794,6 +802,82 @@ public class VisualStudioService : IVisualStudioService
             },
             FailedProjects = lastInfo
         };
+    }
+
+    public async Task<BuildConfigurationInfo> GetBuildConfigurationAsync()
+    {
+        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+        var dte = await GetDteAsync();
+
+        if (!dte.Solution.IsOpen)
+        {
+            return new BuildConfigurationInfo();
+        }
+
+        var solutionBuild = dte.Solution.SolutionBuild;
+        var activeConfiguration = solutionBuild.ActiveConfiguration;
+
+        var result = new BuildConfigurationInfo
+        {
+            ActiveConfiguration = activeConfiguration?.Name ?? string.Empty,
+            ActivePlatform = (activeConfiguration as SolutionConfiguration2)?.PlatformName ?? string.Empty
+        };
+
+        foreach (SolutionConfiguration solutionConfiguration in solutionBuild.SolutionConfigurations)
+        {
+            if (solutionConfiguration is SolutionConfiguration2 configuration)
+            {
+                result.AvailableConfigurations.Add(new BuildConfiguration
+                {
+                    Configuration = configuration.Name,
+                    Platform = configuration.PlatformName
+                });
+            }
+        }
+
+        return result;
+    }
+
+    public async Task<bool> SetBuildConfigurationAsync(string configuration, string platform)
+    {
+        using var activity = VsixTelemetry.Tracer.StartActivity("SetBuildConfiguration");
+
+        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+        var dte = await GetDteAsync();
+
+        if (!dte.Solution.IsOpen
+            || string.IsNullOrWhiteSpace(configuration)
+            || string.IsNullOrWhiteSpace(platform))
+        {
+            return false;
+        }
+
+        var solutionBuild = dte.Solution.SolutionBuild;
+
+        if (solutionBuild.BuildState == vsBuildState.vsBuildStateInProgress)
+        {
+            return false;
+        }
+
+        try
+        {
+            foreach (SolutionConfiguration solutionConfiguration in solutionBuild.SolutionConfigurations)
+            {
+                if (solutionConfiguration is SolutionConfiguration2 candidate
+                    && MatchesBuildConfiguration(candidate.Name, candidate.PlatformName, configuration, platform))
+                {
+                    candidate.Activate();
+                    return true;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            activity?.RecordException(ex);
+        }
+
+        return false;
     }
 
     public async Task<List<SymbolInfo>> GetDocumentSymbolsAsync(string path)


### PR DESCRIPTION
## Summary
- add MCP tools to inspect active and available build configuration/platform pairs
- allow agents to activate an existing Debug/Release and platform combination
- reject changes while a build or debug session is active

## Testing
- dotnet build src/CodingWithCalvin.MCPServer.slnx
- dotnet test src/CodingWithCalvin.MCPServer.Tests/CodingWithCalvin.MCPServer.Tests.csproj (10 passed)