### PR TITLE
feat(tools): add Test Explorer run, debug and stats tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,7 @@ dotnet build src/CodingWithCalvin.VSMCP/CodingWithCalvin.VSMCP.csproj
 - `Services/VisualStudioService.cs` - VS API wrapper for all VS operations
 - `Services/RpcServer.cs` - Named pipe JSON-RPC server
 - `Services/ServerProcessManager.cs` - Server process lifecycle management
+- `Services/TestExplorerInterop.cs` - Reflection bridge to Test Explorer (see the file's remarks for why it cannot be a compile-time reference)
 - `Server/Tools/*.cs` - MCP tool definitions
 
 ## MCP Tools Available
@@ -155,6 +156,15 @@ dotnet build src/CodingWithCalvin.VSMCP/CodingWithCalvin.VSMCP.csproj
 - `clean_solution` - Clean solution
 - `build_cancel` - Cancel build
 - `build_status` - Get build status
+
+### Test Tools
+- `test_run_all` - Run every test in the solution
+- `test_debug_all` - Debug every test in the solution
+- `test_run` - Run tests in a specific class or method
+- `test_debug` - Debug tests in a specific class or method
+- `test_cancel` - Cancel the test run in progress
+- `test_status` - Get run state plus current counts
+- `test_stats` - Get passed/failed/skipped/not-run counts
 
 ## Technology Stack
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,18 @@
 | `output_read` | Read content from an Output window pane |
 | `output_write` | Write a message to an Output window pane |
 
+### 🧪 Test Tools
+
+| Tool | Description |
+|------|-------------|
+| `test_cancel` | Cancel the test run in progress |
+| `test_debug` | Debug the tests in a single class or method |
+| `test_debug_all` | Debug every test in the solution |
+| `test_run` | Run the tests in a single class or method |
+| `test_run_all` | Run every test in the solution |
+| `test_stats` | Get passed, failed, skipped, and not-run counts |
+| `test_status` | Get the run state plus current counts |
+
 ### 🪟 Window Tools
 
 | Tool | Description |

--- a/src/CodingWithCalvin.MCPServer.Server/Program.cs
+++ b/src/CodingWithCalvin.MCPServer.Server/Program.cs
@@ -101,7 +101,8 @@ static async Task RunServerAsync(string pipeName, string host, int port, string 
     .WithTools<NavigationTools>()
     .WithTools<DebuggerTools>()
     .WithTools<DiagnosticsTools>()
-    .WithTools<WindowTools>();
+    .WithTools<WindowTools>()
+    .WithTools<TestTools>();
 
     var app = builder.Build();
 

--- a/src/CodingWithCalvin.MCPServer.Server/RpcClient.cs
+++ b/src/CodingWithCalvin.MCPServer.Server/RpcClient.cs
@@ -65,7 +65,7 @@ public class RpcClient : IVisualStudioRpc, IServerRpc, IDisposable
         }
 
         var tools = new List<ToolInfo>();
-        var toolTypes = new[] { typeof(Tools.SolutionTools), typeof(Tools.DocumentTools), typeof(Tools.BuildTools), typeof(Tools.NavigationTools), typeof(Tools.DebuggerTools), typeof(Tools.DiagnosticsTools), typeof(Tools.WindowTools) };
+        var toolTypes = new[] { typeof(Tools.SolutionTools), typeof(Tools.DocumentTools), typeof(Tools.BuildTools), typeof(Tools.NavigationTools), typeof(Tools.DebuggerTools), typeof(Tools.DiagnosticsTools), typeof(Tools.WindowTools), typeof(Tools.TestTools) };
 
         foreach (var toolType in toolTypes)
         {
@@ -169,6 +169,14 @@ public class RpcClient : IVisualStudioRpc, IServerRpc, IDisposable
     public Task<bool> WriteOutputPaneAsync(string paneIdentifier, string message, bool activate = false)
         => Proxy.WriteOutputPaneAsync(paneIdentifier, message, activate);
     public Task<List<OutputPaneInfo>> GetOutputPanesAsync() => Proxy.GetOutputPanesAsync();
+
+    public Task<bool> RunAllTestsAsync() => Proxy.RunAllTestsAsync();
+    public Task<bool> DebugAllTestsAsync() => Proxy.DebugAllTestsAsync();
+    public Task<TestTargetResult> RunTestsInContextAsync(string target, bool debug)
+        => Proxy.RunTestsInContextAsync(target, debug);
+    public Task<bool> CancelTestRunAsync() => Proxy.CancelTestRunAsync();
+    public Task<TestRunStatus> GetTestRunStatusAsync() => Proxy.GetTestRunStatusAsync();
+    public Task<TestStats> GetTestStatsAsync() => Proxy.GetTestStatsAsync();
 
     public Task<List<WindowInfo>> GetWindowsAsync() => Proxy.GetWindowsAsync();
     public Task<bool> ActivateWindowAsync(string caption) => Proxy.ActivateWindowAsync(caption);

--- a/src/CodingWithCalvin.MCPServer.Server/Tools/TestTools.cs
+++ b/src/CodingWithCalvin.MCPServer.Server/Tools/TestTools.cs
@@ -1,0 +1,93 @@
+using System.ComponentModel;
+using System.Text.Json;
+using System.Threading.Tasks;
+using ModelContextProtocol.Server;
+
+namespace CodingWithCalvin.MCPServer.Server.Tools;
+
+[McpServerToolType]
+public class TestTools
+{
+    private const string StatsUnavailableMessage =
+        "Test Explorer has not been initialized in this Visual Studio session, so no counts are "
+        + "available. Open Test Explorer (window_show with 'TestExplorer') or start a run first. "
+        + "Note this is not the same as the solution having no tests.";
+
+    private readonly RpcClient _rpcClient;
+    private readonly JsonSerializerOptions _jsonOptions;
+
+    public TestTools(RpcClient rpcClient)
+    {
+        _rpcClient = rpcClient;
+        _jsonOptions = new JsonSerializerOptions { WriteIndented = true };
+    }
+
+    [McpServerTool(Name = "test_run_all", Destructive = false)]
+    [Description("Run every test in the solution via Test Explorer. The run starts asynchronously and this returns immediately; poll test_status to observe completion. Requires a solution with discovered tests.")]
+    public async Task<string> RunAllTestsAsync()
+    {
+        var started = await _rpcClient.RunAllTestsAsync();
+        return started
+            ? "Test run started. Poll test_status for progress."
+            : "Failed to start the test run. Test Explorer may still be discovering tests, or the solution has none.";
+    }
+
+    [McpServerTool(Name = "test_debug_all", Destructive = false)]
+    [Description("Debug every test in the solution via Test Explorer, stopping on any breakpoints that are set. The run starts asynchronously and this returns immediately; poll test_status to observe completion.")]
+    public async Task<string> DebugAllTestsAsync()
+    {
+        var started = await _rpcClient.DebugAllTestsAsync();
+        return started
+            ? "Test debug run started. Poll test_status for progress."
+            : "Failed to start the test debug run. Test Explorer may still be discovering tests, or the solution has none.";
+    }
+
+    [McpServerTool(Name = "test_run", Destructive = false)]
+    [Description("Run the tests in a single test class or test method. Accepts a simple name ('CalculatorTests', 'Add_ReturnsSum') or a fully qualified one ('MyApp.Tests.CalculatorTests.Add_ReturnsSum'); a fully qualified name is matched first and avoids ambiguity. The run starts asynchronously; poll test_status to observe completion.")]
+    public async Task<string> RunTestAsync(
+        [Description("Test class or test method name to run. Fully qualified names are preferred when several types share a simple name.")] string target)
+    {
+        var result = await _rpcClient.RunTestsInContextAsync(target, debug: false);
+        return JsonSerializer.Serialize(result, _jsonOptions);
+    }
+
+    [McpServerTool(Name = "test_debug", Destructive = false)]
+    [Description("Debug the tests in a single test class or test method, stopping on any breakpoints that are set. Accepts a simple or fully qualified name; a fully qualified name is matched first and avoids ambiguity. The run starts asynchronously; poll test_status to observe completion.")]
+    public async Task<string> DebugTestAsync(
+        [Description("Test class or test method name to debug. Fully qualified names are preferred when several types share a simple name.")] string target)
+    {
+        var result = await _rpcClient.RunTestsInContextAsync(target, debug: true);
+        return JsonSerializer.Serialize(result, _jsonOptions);
+    }
+
+    [McpServerTool(Name = "test_cancel", Destructive = false, Idempotent = true)]
+    [Description("Cancel the test run that is currently in progress.")]
+    public async Task<string> CancelTestRunAsync()
+    {
+        var cancelled = await _rpcClient.CancelTestRunAsync();
+        return cancelled
+            ? "Test run cancelled"
+            : "No test run is currently in progress";
+    }
+
+    [McpServerTool(Name = "test_status", ReadOnly = true)]
+    [Description("Get the Test Explorer run state plus current counts. State is one of 'NoRunObserved', 'Discovering', 'Running', 'Canceling', 'Completed', or 'Canceled'. Use this to poll for completion after test_run_all, test_run, or their debug equivalents. State is only tracked for runs started after this extension first contacted Test Explorer.")]
+    public async Task<string> GetTestStatusAsync()
+    {
+        var status = await _rpcClient.GetTestRunStatusAsync();
+        return JsonSerializer.Serialize(status, _jsonOptions);
+    }
+
+    [McpServerTool(Name = "test_stats", ReadOnly = true)]
+    [Description("Get the passed, failed, skipped and not-run test counts from Test Explorer. Returns counts only - Visual Studio exposes no public API for the names of the individual failed or not-run tests.")]
+    public async Task<string> GetTestStatsAsync()
+    {
+        var stats = await _rpcClient.GetTestStatsAsync();
+        if (!stats.Available)
+        {
+            return StatsUnavailableMessage;
+        }
+
+        return JsonSerializer.Serialize(stats, _jsonOptions);
+    }
+}

--- a/src/CodingWithCalvin.MCPServer.Shared/Models/TestModels.cs
+++ b/src/CodingWithCalvin.MCPServer.Shared/Models/TestModels.cs
@@ -1,0 +1,64 @@
+namespace CodingWithCalvin.MCPServer.Shared.Models;
+
+/// <summary>
+/// Aggregate test counts as reported by the Test Explorer window.
+/// </summary>
+public class TestStats
+{
+    /// <summary>
+    /// False when Test Explorer has not been initialized in this Visual Studio session.
+    /// The counts are meaningless when this is false, and must not be read as "no tests".
+    /// </summary>
+    public bool Available { get; set; }
+
+    public int Passed { get; set; }
+    public int Failed { get; set; }
+    public int Skipped { get; set; }
+    public int NotRun { get; set; }
+}
+
+/// <summary>
+/// Test Explorer run state, plus the counts as of the most recent state change.
+/// </summary>
+public class TestRunStatus
+{
+    /// <summary>
+    /// One of "NoRunObserved", "Discovering", "Running", "Canceling", "Completed", or "Canceled".
+    /// </summary>
+    public string State { get; set; } = string.Empty;
+
+    /// <summary>
+    /// True while discovery or execution is still in flight.
+    /// </summary>
+    public bool IsRunning { get; set; }
+
+    /// <summary>
+    /// Raw Test Explorer operation name behind <see cref="State"/>, retained for diagnostics.
+    /// Null until a state change has been observed.
+    /// </summary>
+    public string? LastOperation { get; set; }
+
+    public TestStats Stats { get; set; } = new();
+}
+
+/// <summary>
+/// Outcome of asking Test Explorer to start a run for a specific class or method.
+/// </summary>
+public class TestTargetResult
+{
+    public bool Started { get; set; }
+
+    /// <summary>
+    /// Fully qualified name of the symbol the caret was placed on, when one was resolved.
+    /// </summary>
+    public string? ResolvedTarget { get; set; }
+
+    public string? FilePath { get; set; }
+    public int Line { get; set; }
+
+    /// <summary>
+    /// Populated when <see cref="Started"/> is false, or when the resolved target was
+    /// ambiguous and the first match was used.
+    /// </summary>
+    public string? Message { get; set; }
+}

--- a/src/CodingWithCalvin.MCPServer.Shared/RpcContracts.cs
+++ b/src/CodingWithCalvin.MCPServer.Shared/RpcContracts.cs
@@ -73,6 +73,14 @@ public interface IVisualStudioRpc
     Task<bool> WriteOutputPaneAsync(string paneIdentifier, string message, bool activate = false);
     Task<List<OutputPaneInfo>> GetOutputPanesAsync();
 
+    // Test Explorer tools
+    Task<bool> RunAllTestsAsync();
+    Task<bool> DebugAllTestsAsync();
+    Task<TestTargetResult> RunTestsInContextAsync(string target, bool debug);
+    Task<bool> CancelTestRunAsync();
+    Task<TestRunStatus> GetTestRunStatusAsync();
+    Task<TestStats> GetTestStatsAsync();
+
     // Window management tools
     Task<List<WindowInfo>> GetWindowsAsync();
     Task<bool> ActivateWindowAsync(string caption);

--- a/src/CodingWithCalvin.MCPServer.Tests/TestExplorerInteropTests.cs
+++ b/src/CodingWithCalvin.MCPServer.Tests/TestExplorerInteropTests.cs
@@ -1,0 +1,266 @@
+using System;
+using System.ComponentModel.Composition;
+using System.ComponentModel.Composition.Hosting;
+using System.ComponentModel.Composition.Primitives;
+using CodingWithCalvin.MCPServer.Services;
+using Microsoft.VisualStudio.ComponentModelHost;
+using Microsoft.VisualStudio.TestWindow.Extensibility;
+using Xunit;
+
+namespace CodingWithCalvin.MCPServer.Tests;
+
+/// <summary>
+/// Covers the reflection bridge to Test Explorer.
+/// </summary>
+/// <remarks>
+/// Microsoft.VisualStudio.TestWindow.Interfaces.dll cannot be referenced at build time, so
+/// <see cref="TestExplorerInterop"/> resolves its services by MEF contract name and reads them
+/// reflectively. These tests stand up a real MEF container holding stand-in parts declared in
+/// the genuine namespace and shaped like the real ones, which exercises the contract-name
+/// lookup, the interface discovery, the property reads and the explicitly implemented event
+/// subscription rather than just the pure helpers.
+/// </remarks>
+public class TestExplorerInteropTests
+{
+    [Fact]
+    public void GetStats_ReportsUnavailable_WhenComponentModelMissing()
+    {
+        var interop = new TestExplorerInterop(() => null);
+
+        var stats = interop.GetStats();
+
+        Assert.False(stats.Available);
+    }
+
+    [Fact]
+    public void GetStats_ReportsUnavailable_WhenTestExplorerNotRunning()
+    {
+        using var host = new StubHost();
+        host.Stats.IsTestExplorerStatsServiceRunning = false;
+        host.Stats.Counts = new TestExplorerStats { PassedTestCount = 7 };
+
+        var stats = new TestExplorerInterop(host.Accessor).GetStats();
+
+        // Counts must not leak through as zeros that read like "solution has no tests".
+        Assert.False(stats.Available);
+        Assert.Equal(0, stats.Passed);
+    }
+
+    [Fact]
+    public void GetStats_ReadsCounts_WhenTestExplorerRunning()
+    {
+        using var host = new StubHost();
+        host.Stats.IsTestExplorerStatsServiceRunning = true;
+        host.Stats.Counts = new TestExplorerStats
+        {
+            PassedTestCount = 12,
+            FailedTestCount = 3,
+            SkippedTestCount = 1,
+            NotRunTestCount = 4
+        };
+
+        var stats = new TestExplorerInterop(host.Accessor).GetStats();
+
+        Assert.True(stats.Available);
+        Assert.Equal(12, stats.Passed);
+        Assert.Equal(3, stats.Failed);
+        Assert.Equal(1, stats.Skipped);
+        Assert.Equal(4, stats.NotRun);
+    }
+
+    [Fact]
+    public void GetRunStatus_ReportsNoRunObserved_BeforeAnyStateChange()
+    {
+        using var host = new StubHost();
+
+        var status = new TestExplorerInterop(host.Accessor).GetRunStatus();
+
+        Assert.Equal("NoRunObserved", status.State);
+        Assert.False(status.IsRunning);
+        Assert.Null(status.LastOperation);
+    }
+
+    [Fact]
+    public void GetRunStatus_TracksExecutionThroughToCompletion()
+    {
+        using var host = new StubHost();
+        var interop = new TestExplorerInterop(host.Accessor);
+        interop.EnsureTracking();
+
+        host.Operations.Raise(TestOperationStates.TestExecutionStarted);
+        var running = interop.GetRunStatus();
+
+        host.Operations.Raise(TestOperationStates.TestExecutionFinished);
+        var finished = interop.GetRunStatus();
+
+        Assert.Equal("Running", running.State);
+        Assert.True(running.IsRunning);
+
+        Assert.Equal("Completed", finished.State);
+        Assert.False(finished.IsRunning);
+        Assert.Equal("TestExecutionFinished", finished.LastOperation);
+    }
+
+    [Fact]
+    public void GetRunStatus_ReportsCanceled_AfterCancellation()
+    {
+        using var host = new StubHost();
+        var interop = new TestExplorerInterop(host.Accessor);
+        interop.EnsureTracking();
+
+        host.Operations.Raise(TestOperationStates.TestExecutionStarted);
+        host.Operations.Raise(TestOperationStates.TestExecutionCancelAndFinished);
+
+        Assert.Equal("Canceled", interop.GetRunStatus().State);
+    }
+
+    [Fact]
+    public void GetRunStatus_KeepsRunOutcome_WhenDiscoveryRunsAfterwards()
+    {
+        using var host = new StubHost();
+        var interop = new TestExplorerInterop(host.Accessor);
+        interop.EnsureTracking();
+
+        host.Operations.Raise(TestOperationStates.TestExecutionFinished);
+        host.Operations.Raise(TestOperationStates.DiscoveryFinished);
+
+        // A discovery pass triggered by editing code must not erase the last run's outcome.
+        Assert.Equal("Completed", interop.GetRunStatus().State);
+    }
+
+    [Fact]
+    public void EnsureTracking_SubscribesOnlyOnce()
+    {
+        using var host = new StubHost();
+        var interop = new TestExplorerInterop(host.Accessor);
+
+        interop.EnsureTracking();
+        interop.EnsureTracking();
+        interop.EnsureTracking();
+
+        Assert.Equal(1, host.Operations.SubscriberCount);
+    }
+
+    [Fact]
+    public void EnsureTracking_DoesNotThrow_WhenComponentModelMissing()
+    {
+        var interop = new TestExplorerInterop(() => null);
+
+        interop.EnsureTracking();
+
+        Assert.Equal("NoRunObserved", interop.GetRunStatus().State);
+    }
+
+    [Theory]
+    [InlineData(null, null, "NoRunObserved")]
+    [InlineData("DiscoveryStarted", null, "Discovering")]
+    [InlineData("DiscoveryStarting", null, "Discovering")]
+    [InlineData("DiscoveryFinished", null, "NoRunObserved")]
+    [InlineData("TestExecutionStarted", "TestExecutionStarted", "Running")]
+    [InlineData("TestExecutionStarting", "TestExecutionStarting", "Running")]
+    [InlineData("TestExecutionCanceling", "TestExecutionCanceling", "Canceling")]
+    [InlineData("TestExecutionFinished", "TestExecutionFinished", "Completed")]
+    [InlineData("TestExecutionCancelAndFinished", "TestExecutionCancelAndFinished", "Canceled")]
+    [InlineData("DiscoveryStarted", "TestExecutionFinished", "Discovering")]
+    [InlineData("DiscoveryFinished", "TestExecutionFinished", "Completed")]
+    public void DeriveState_CollapsesOperationNames(string? last, string? lastExecution, string expected)
+    {
+        Assert.Equal(expected, TestExplorerInterop.DeriveState(last, lastExecution));
+    }
+
+    /// <summary>
+    /// A MEF container holding the stand-in Test Explorer parts, exposed through the
+    /// <see cref="IComponentModel"/> shape that <see cref="TestExplorerInterop"/> consumes.
+    /// </summary>
+    private sealed class StubHost : IDisposable
+    {
+        private readonly CompositionContainer _container;
+        private readonly StubComponentModel _componentModel;
+
+        internal StubHost()
+        {
+            _container = new CompositionContainer(
+                new TypeCatalog(typeof(StubStatsService), typeof(StubOperationState)));
+            _componentModel = new StubComponentModel(_container);
+
+            Stats = (StubStatsService)_container.GetExportedValue<ITestExplorerStatsService>();
+            Operations = (StubOperationState)_container.GetExportedValue<IOperationState>();
+        }
+
+        internal StubStatsService Stats { get; }
+
+        internal StubOperationState Operations { get; }
+
+        internal Func<IComponentModel?> Accessor => () => _componentModel;
+
+        public void Dispose() => _container.Dispose();
+    }
+
+    private sealed class StubComponentModel : IComponentModel
+    {
+        internal StubComponentModel(ExportProvider exportProvider)
+        {
+            DefaultExportProvider = exportProvider;
+        }
+
+        public ExportProvider DefaultExportProvider { get; }
+
+        public ComposablePartCatalog DefaultCatalog => throw new NotSupportedException();
+
+        public ICompositionService DefaultCompositionService => throw new NotSupportedException();
+
+#pragma warning disable CS0618, CS0672 // Obsolete member is part of the interface being stubbed.
+        public ComposablePartCatalog GetCatalog(string catalogName) => throw new NotSupportedException();
+#pragma warning restore CS0618, CS0672
+
+        public System.Collections.Generic.IEnumerable<T> GetExtensions<T>() where T : class
+            => throw new NotSupportedException();
+
+        public T GetService<T>() where T : class => throw new NotSupportedException();
+    }
+
+    [Export(typeof(ITestExplorerStatsService))]
+    [PartCreationPolicy(CreationPolicy.Shared)]
+    private sealed class StubStatsService : ITestExplorerStatsService
+    {
+        internal TestExplorerStats Counts { get; set; }
+
+        public bool IsTestExplorerStatsServiceRunning { get; set; }
+
+        TestExplorerStats ITestExplorerStatsService.TestExplorerStats => Counts;
+
+        public event EventHandler<TestExplorerStats>? TestExplorerStatsChanged;
+
+        internal void RaiseStatsChanged() => TestExplorerStatsChanged?.Invoke(this, Counts);
+    }
+
+    /// <summary>
+    /// Implements StateChanged explicitly, matching the real OperationBroker, so the interop's
+    /// interface-based event lookup is genuinely exercised.
+    /// </summary>
+    [Export(typeof(IOperationState))]
+    [PartCreationPolicy(CreationPolicy.Shared)]
+    private sealed class StubOperationState : IOperationState
+    {
+        private EventHandler<OperationStateChangedEventArgs>? _stateChanged;
+
+        internal int SubscriberCount { get; private set; }
+
+        event EventHandler<OperationStateChangedEventArgs> IOperationState.StateChanged
+        {
+            add
+            {
+                _stateChanged += value;
+                SubscriberCount++;
+            }
+            remove
+            {
+                _stateChanged -= value;
+                SubscriberCount--;
+            }
+        }
+
+        internal void Raise(TestOperationStates state) =>
+            _stateChanged?.Invoke(this, new OperationStateChangedEventArgs { State = state });
+    }
+}

--- a/src/CodingWithCalvin.MCPServer.Tests/TestTargetSelectionTests.cs
+++ b/src/CodingWithCalvin.MCPServer.Tests/TestTargetSelectionTests.cs
@@ -1,0 +1,107 @@
+using System.Collections.Generic;
+using CodingWithCalvin.MCPServer.Services;
+using CodingWithCalvin.MCPServer.Shared.Models;
+using Xunit;
+
+namespace CodingWithCalvin.MCPServer.Tests;
+
+/// <summary>
+/// Covers how a caller-supplied test name is resolved to the symbol the caret gets placed on.
+/// Test Explorer's run-in-context commands act on the caret, so picking the wrong symbol here
+/// silently runs the wrong tests rather than failing.
+/// </summary>
+public class TestTargetSelectionTests
+{
+    [Fact]
+    public void SelectTestTarget_PrefersExactFullNameOverSimpleName()
+    {
+        var candidates = new List<SymbolInfo>
+        {
+            Symbol("CalculatorTests", "Other.CalculatorTests", SymbolKind.Class),
+            Symbol("CalculatorTests", "MyApp.Tests.CalculatorTests", SymbolKind.Class)
+        };
+
+        var selected = VisualStudioService.SelectTestTarget(candidates, "MyApp.Tests.CalculatorTests");
+
+        Assert.Equal("MyApp.Tests.CalculatorTests", selected?.FullName);
+    }
+
+    [Fact]
+    public void SelectTestTarget_MatchesSimpleName()
+    {
+        var candidates = new List<SymbolInfo>
+        {
+            Symbol("Helper", "MyApp.Tests.Helper", SymbolKind.Class),
+            Symbol("Add_ReturnsSum", "MyApp.Tests.CalculatorTests.Add_ReturnsSum", SymbolKind.Function)
+        };
+
+        var selected = VisualStudioService.SelectTestTarget(candidates, "Add_ReturnsSum");
+
+        Assert.Equal("MyApp.Tests.CalculatorTests.Add_ReturnsSum", selected?.FullName);
+    }
+
+    [Fact]
+    public void SelectTestTarget_FallsBackToTrailingSegmentMatch()
+    {
+        var candidates = new List<SymbolInfo>
+        {
+            Symbol("Unrelated", "MyApp.Tests.Unrelated", SymbolKind.Class),
+            Symbol("Add_ReturnsSum", "MyApp.Tests.CalculatorTests.Add_ReturnsSum", SymbolKind.Function)
+        };
+
+        var selected = VisualStudioService.SelectTestTarget(
+            candidates,
+            "CalculatorTests.Add_ReturnsSum");
+
+        Assert.Equal("MyApp.Tests.CalculatorTests.Add_ReturnsSum", selected?.FullName);
+    }
+
+    [Fact]
+    public void SelectTestTarget_PrefersExactSimpleNameOverTrailingSegment()
+    {
+        var candidates = new List<SymbolInfo>
+        {
+            Symbol("Nested", "MyApp.Tests.Outer.Nested", SymbolKind.Class),
+            Symbol("Nested", "MyApp.Tests.Nested", SymbolKind.Class)
+        };
+
+        var selected = VisualStudioService.SelectTestTarget(candidates, "Nested");
+
+        // Both end with ".Nested"; the exact simple-name rule runs first and takes the earlier
+        // candidate, so the result is deterministic rather than dependent on suffix ordering.
+        Assert.Equal("MyApp.Tests.Outer.Nested", selected?.FullName);
+    }
+
+    [Fact]
+    public void SelectTestTarget_ReturnsNull_WhenNoCandidates()
+    {
+        var selected = VisualStudioService.SelectTestTarget(new List<SymbolInfo>(), "Anything");
+
+        Assert.Null(selected);
+    }
+
+    [Fact]
+    public void SelectTestTarget_FallsBackToFirstCandidate_WhenNothingMatches()
+    {
+        var candidates = new List<SymbolInfo>
+        {
+            Symbol("CalculatorTests", "MyApp.Tests.CalculatorTests", SymbolKind.Class)
+        };
+
+        // The caller's text already matched during the workspace symbol search, so a candidate
+        // that fails the stricter rules here is still a better answer than nothing.
+        var selected = VisualStudioService.SelectTestTarget(candidates, "Calculator");
+
+        Assert.Equal("MyApp.Tests.CalculatorTests", selected?.FullName);
+    }
+
+    private static SymbolInfo Symbol(string name, string fullName, SymbolKind kind) => new()
+    {
+        Name = name,
+        FullName = fullName,
+        Kind = kind,
+        FilePath = @"C:\src\Tests.cs",
+        StartLine = 10,
+        StartColumn = 5
+    };
+}

--- a/src/CodingWithCalvin.MCPServer.Tests/TestWindowStandIns.cs
+++ b/src/CodingWithCalvin.MCPServer.Tests/TestWindowStandIns.cs
@@ -1,0 +1,55 @@
+using System;
+
+// Stand-ins for the Test Explorer extensibility types, declared in the real namespace so that
+// their full names match the MEF contract names TestExplorerInterop looks up.
+//
+// Microsoft.VisualStudio.TestWindow.Interfaces.dll ships only inside the Visual Studio
+// installation: it is absent from the Microsoft.VisualStudio.SDK metapackage, nuget.org carries
+// nothing newer than 11.0.61030 (2012), and $(DevEnvDir) is undefined under `dotnet build`. The
+// production code therefore resolves these services by contract name and reads them
+// reflectively, and these declarations let the tests drive that path without Visual Studio.
+//
+// Shapes are transcribed from the shipped assembly and are identical in VS 2022 17.14 and
+// VS 2026 18.0. Only the members the interop touches are reproduced.
+namespace Microsoft.VisualStudio.TestWindow.Extensibility;
+
+public struct TestExplorerStats
+{
+    public int PassedTestCount { get; set; }
+    public int FailedTestCount { get; set; }
+    public int SkippedTestCount { get; set; }
+    public int NotRunTestCount { get; set; }
+}
+
+public interface ITestExplorerStatsService
+{
+    TestExplorerStats TestExplorerStats { get; }
+    bool IsTestExplorerStatsServiceRunning { get; }
+    event EventHandler<TestExplorerStats> TestExplorerStatsChanged;
+}
+
+public enum TestOperationStates
+{
+    None = 0x00000000,
+    Discovery = 0x00010000,
+    DiscoveryStarting = 0x00010008,
+    DiscoveryStarted = 0x00010001,
+    DiscoveryFinished = 0x00010004,
+    DiscoveryCanceled = 0x00010006,
+    TestExecution = 0x00020000,
+    TestExecutionStarting = 0x00020008,
+    TestExecutionStarted = 0x00020001,
+    TestExecutionCanceling = 0x00020003,
+    TestExecutionFinished = 0x00020004,
+    TestExecutionCancelAndFinished = 0x00020006
+}
+
+public class OperationStateChangedEventArgs : EventArgs
+{
+    public TestOperationStates State { get; set; }
+}
+
+public interface IOperationState
+{
+    event EventHandler<OperationStateChangedEventArgs> StateChanged;
+}

--- a/src/CodingWithCalvin.MCPServer/Services/IVisualStudioService.cs
+++ b/src/CodingWithCalvin.MCPServer/Services/IVisualStudioService.cs
@@ -68,6 +68,14 @@ public interface IVisualStudioService
     Task<bool> WriteOutputPaneAsync(string paneIdentifier, string message, bool activate = false);
     Task<List<OutputPaneInfo>> GetOutputPanesAsync();
 
+    // Test Explorer tools
+    Task<bool> RunAllTestsAsync();
+    Task<bool> DebugAllTestsAsync();
+    Task<TestTargetResult> RunTestsInContextAsync(string target, bool debug);
+    Task<bool> CancelTestRunAsync();
+    Task<TestRunStatus> GetTestRunStatusAsync();
+    Task<TestStats> GetTestStatsAsync();
+
     Task<List<WindowInfo>> GetWindowsAsync();
     Task<bool> ActivateWindowAsync(string caption);
     Task<bool> ShowToolWindowAsync(string name);

--- a/src/CodingWithCalvin.MCPServer/Services/RpcServer.cs
+++ b/src/CodingWithCalvin.MCPServer/Services/RpcServer.cs
@@ -279,6 +279,14 @@ public class RpcServer : IRpcServer, IVisualStudioRpc
         => _vsService.WriteOutputPaneAsync(paneIdentifier, message, activate);
     public Task<List<OutputPaneInfo>> GetOutputPanesAsync() => _vsService.GetOutputPanesAsync();
 
+    public Task<bool> RunAllTestsAsync() => _vsService.RunAllTestsAsync();
+    public Task<bool> DebugAllTestsAsync() => _vsService.DebugAllTestsAsync();
+    public Task<TestTargetResult> RunTestsInContextAsync(string target, bool debug)
+        => _vsService.RunTestsInContextAsync(target, debug);
+    public Task<bool> CancelTestRunAsync() => _vsService.CancelTestRunAsync();
+    public Task<TestRunStatus> GetTestRunStatusAsync() => _vsService.GetTestRunStatusAsync();
+    public Task<TestStats> GetTestStatsAsync() => _vsService.GetTestStatsAsync();
+
     public Task<List<WindowInfo>> GetWindowsAsync() => _vsService.GetWindowsAsync();
     public Task<bool> ActivateWindowAsync(string caption) => _vsService.ActivateWindowAsync(caption);
     public Task<bool> ShowToolWindowAsync(string name) => _vsService.ShowToolWindowAsync(name);

--- a/src/CodingWithCalvin.MCPServer/Services/TestExplorerInterop.cs
+++ b/src/CodingWithCalvin.MCPServer/Services/TestExplorerInterop.cs
@@ -1,0 +1,321 @@
+using System;
+using System.ComponentModel.Composition.Primitives;
+using System.Linq;
+using System.Reflection;
+using CodingWithCalvin.MCPServer.Shared.Models;
+using CodingWithCalvin.Otel4Vsix;
+using Microsoft.VisualStudio.ComponentModelHost;
+
+namespace CodingWithCalvin.MCPServer.Services;
+
+/// <summary>
+/// Reflection bridge to the Test Explorer extensibility services.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The types used here live in <c>Microsoft.VisualStudio.TestWindow.Interfaces.dll</c>, which
+/// ships only inside the Visual Studio installation. It cannot be referenced at compile time:
+/// nuget.org carries nothing newer than 11.0.61030 (2012), it is absent from the
+/// Microsoft.VisualStudio.SDK metapackage, and <c>$(DevEnvDir)</c> is undefined under
+/// <c>dotnet build</c> — which is how this repo builds both locally and in CI — so a HintPath
+/// would break the build outright.
+/// </para>
+/// <para>
+/// The surface needed is small and stable: one bool, one struct of four ints, and one event.
+/// It is byte-identical between VS 2022 17.14 and VS 2026 18.0, the range the VSIX manifest
+/// targets. Both services are MEF parts (<c>TestExplorerStatsService</c> exports
+/// <c>ITestExplorerStatsService</c>, <c>OperationBroker</c> exports <c>IOperationState</c>), so
+/// they are resolved by contract name and read reflectively.
+/// </para>
+/// <para>
+/// Every failure path degrades to "unavailable" rather than throwing. Test Explorer may never
+/// have been opened, and on a future Visual Studio the shape could change; neither should take
+/// an MCP tool call down with it.
+/// </para>
+/// </remarks>
+internal sealed class TestExplorerInterop
+{
+    private const string StatsServiceContract =
+        "Microsoft.VisualStudio.TestWindow.Extensibility.ITestExplorerStatsService";
+    private const string OperationStateContract =
+        "Microsoft.VisualStudio.TestWindow.Extensibility.IOperationState";
+
+    private const string DiscoveryPrefix = "Discovery";
+    private const string ExecutionPrefix = "TestExecution";
+
+    private readonly object _gate = new object();
+    private readonly Func<IComponentModel?> _componentModelAccessor;
+
+    private bool _statsResolved;
+    private object? _statsService;
+    private PropertyInfo? _isRunningProperty;
+    private PropertyInfo? _statsProperty;
+    private PropertyInfo? _passedProperty;
+    private PropertyInfo? _failedProperty;
+    private PropertyInfo? _skippedProperty;
+    private PropertyInfo? _notRunProperty;
+
+    private bool _trackingAttempted;
+    private string? _lastOperation;
+    private string? _lastExecutionOperation;
+
+    internal TestExplorerInterop(Func<IComponentModel?> componentModelAccessor)
+    {
+        _componentModelAccessor = componentModelAccessor;
+    }
+
+    /// <summary>
+    /// Reads the current Test Explorer counts. Returns <see cref="TestStats.Available"/> false
+    /// when Test Explorer has not been initialized, so that an uninitialized window is not
+    /// reported as a solution with zero tests.
+    /// </summary>
+    internal TestStats GetStats()
+    {
+        try
+        {
+            lock (_gate)
+            {
+                if (!TryResolveStatsService())
+                {
+                    return new TestStats();
+                }
+
+                if (_isRunningProperty!.GetValue(_statsService) is not true)
+                {
+                    return new TestStats();
+                }
+
+                var stats = _statsProperty!.GetValue(_statsService);
+                if (stats == null)
+                {
+                    return new TestStats();
+                }
+
+                return new TestStats
+                {
+                    Available = true,
+                    Passed = ReadCount(_passedProperty, stats),
+                    Failed = ReadCount(_failedProperty, stats),
+                    Skipped = ReadCount(_skippedProperty, stats),
+                    NotRun = ReadCount(_notRunProperty, stats)
+                };
+            }
+        }
+        catch (Exception ex)
+        {
+            VsixTelemetry.TrackException(ex);
+            return new TestStats();
+        }
+    }
+
+    /// <summary>
+    /// Reports the tracked run state alongside the current counts. State is only observed from
+    /// the point <see cref="EnsureTracking"/> first succeeds, so a run started outside this
+    /// extension before then reads as "NoRunObserved".
+    /// </summary>
+    internal TestRunStatus GetRunStatus()
+    {
+        EnsureTracking();
+
+        string? lastOperation;
+        string? lastExecution;
+
+        lock (_gate)
+        {
+            lastOperation = _lastOperation;
+            lastExecution = _lastExecutionOperation;
+        }
+
+        var state = DeriveState(lastOperation, lastExecution);
+
+        return new TestRunStatus
+        {
+            State = state,
+            IsRunning = state is "Discovering" or "Running" or "Canceling",
+            LastOperation = lastOperation,
+            Stats = GetStats()
+        };
+    }
+
+    /// <summary>
+    /// Subscribes to Test Explorer operation state changes. Safe to call repeatedly; the
+    /// subscription is attempted once and the outcome cached either way.
+    /// </summary>
+    internal void EnsureTracking()
+    {
+        lock (_gate)
+        {
+            if (_trackingAttempted)
+            {
+                return;
+            }
+
+            _trackingAttempted = true;
+
+            try
+            {
+                var operationState = ResolveExport(OperationStateContract);
+                if (operationState == null)
+                {
+                    return;
+                }
+
+                // IOperationState.StateChanged is implemented explicitly on OperationBroker, so
+                // the event has to be reached through the interface rather than the class.
+                var contract = FindInterface(operationState, OperationStateContract);
+                var stateChanged = contract?.GetEvent("StateChanged");
+                if (stateChanged?.EventHandlerType == null)
+                {
+                    return;
+                }
+
+                var callback = typeof(TestExplorerInterop).GetMethod(
+                    nameof(OnOperationStateChanged),
+                    BindingFlags.Instance | BindingFlags.NonPublic);
+                if (callback == null)
+                {
+                    return;
+                }
+
+                // The event is EventHandler<OperationStateChangedEventArgs>; the callback takes
+                // the EventArgs base. Delegate creation allows that contravariance.
+                var handler = Delegate.CreateDelegate(
+                    stateChanged.EventHandlerType,
+                    this,
+                    callback,
+                    throwOnBindFailure: false);
+                if (handler == null)
+                {
+                    return;
+                }
+
+                stateChanged.AddEventHandler(operationState, handler);
+            }
+            catch (Exception ex)
+            {
+                VsixTelemetry.TrackException(ex);
+            }
+        }
+    }
+
+    private void OnOperationStateChanged(object sender, EventArgs args)
+    {
+        try
+        {
+            var operation = args.GetType().GetProperty("State")?.GetValue(args)?.ToString();
+            if (string.IsNullOrEmpty(operation))
+            {
+                return;
+            }
+
+            lock (_gate)
+            {
+                _lastOperation = operation;
+
+                if (operation!.StartsWith(ExecutionPrefix, StringComparison.Ordinal))
+                {
+                    _lastExecutionOperation = operation;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            VsixTelemetry.TrackException(ex);
+        }
+    }
+
+    /// <summary>
+    /// Collapses the raw Test Explorer operation names into the small state set the tools
+    /// report. Discovery is only surfaced while it is in flight, so that a discovery pass
+    /// triggered after a run does not erase the outcome of that run.
+    /// </summary>
+    internal static string DeriveState(string? lastOperation, string? lastExecutionOperation)
+    {
+        if (lastOperation != null
+            && lastOperation.StartsWith(DiscoveryPrefix, StringComparison.Ordinal)
+            && IsInFlight(lastOperation))
+        {
+            return "Discovering";
+        }
+
+        return lastExecutionOperation switch
+        {
+            null => "NoRunObserved",
+            "TestExecutionFinished" => "Completed",
+            "TestExecutionCancelAndFinished" => "Canceled",
+            "TestExecutionCanceling" => "Canceling",
+            _ => "Running"
+        };
+    }
+
+    private static bool IsInFlight(string operation) =>
+        !operation.EndsWith("Finished", StringComparison.Ordinal)
+        && !operation.EndsWith("Canceled", StringComparison.Ordinal);
+
+    private static int ReadCount(PropertyInfo? property, object stats) =>
+        property?.GetValue(stats) is int value ? value : 0;
+
+    private bool TryResolveStatsService()
+    {
+        if (_statsResolved)
+        {
+            return _statsService != null;
+        }
+
+        _statsResolved = true;
+
+        var service = ResolveExport(StatsServiceContract);
+        if (service == null)
+        {
+            return false;
+        }
+
+        var contract = FindInterface(service, StatsServiceContract);
+        if (contract == null)
+        {
+            return false;
+        }
+
+        _isRunningProperty = contract.GetProperty("IsTestExplorerStatsServiceRunning");
+        _statsProperty = contract.GetProperty("TestExplorerStats");
+        if (_isRunningProperty == null || _statsProperty == null)
+        {
+            return false;
+        }
+
+        var statsType = _statsProperty.PropertyType;
+        _passedProperty = statsType.GetProperty("PassedTestCount");
+        _failedProperty = statsType.GetProperty("FailedTestCount");
+        _skippedProperty = statsType.GetProperty("SkippedTestCount");
+        _notRunProperty = statsType.GetProperty("NotRunTestCount");
+
+        _statsService = service;
+        return true;
+    }
+
+    private object? ResolveExport(string contractName)
+    {
+        var componentModel = _componentModelAccessor();
+        if (componentModel == null)
+        {
+            return null;
+        }
+
+        var definition = new ImportDefinition(
+            d => d.ContractName == contractName,
+            contractName,
+            ImportCardinality.ZeroOrMore,
+            isRecomposable: false,
+            isPrerequisite: false);
+
+        return componentModel.DefaultExportProvider
+            .GetExports(definition)
+            .FirstOrDefault()
+            ?.Value;
+    }
+
+    private static Type? FindInterface(object instance, string fullName) =>
+        instance.GetType()
+            .GetInterfaces()
+            .FirstOrDefault(i => string.Equals(i.FullName, fullName, StringComparison.Ordinal));
+}

--- a/src/CodingWithCalvin.MCPServer/Services/VisualStudioService.cs
+++ b/src/CodingWithCalvin.MCPServer/Services/VisualStudioService.cs
@@ -2587,4 +2587,224 @@ public class VisualStudioService : IVisualStudioService
     {
         return ToolWindowCommands.Keys;
     }
+
+    /// <summary>
+    /// Test Explorer exposes no documented cancel command, so the first candidate that the
+    /// running Visual Studio actually recognises is used.
+    /// </summary>
+    private static readonly string[] CancelTestRunCommands =
+    {
+        "TestExplorer.CancelTestRun",
+        "TestExplorer.CancelTests"
+    };
+
+    private TestExplorerInterop? _testExplorer;
+
+    private TestExplorerInterop TestExplorer =>
+        _testExplorer ??= new TestExplorerInterop(
+            () => ServiceProvider.GetService(typeof(SComponentModel)) as IComponentModel);
+
+    public async Task<bool> RunAllTestsAsync()
+    {
+        using var activity = VsixTelemetry.Tracer.StartActivity("RunAllTests");
+        return await StartTestRunAsync("TestExplorer.RunAllTests", activity);
+    }
+
+    public async Task<bool> DebugAllTestsAsync()
+    {
+        using var activity = VsixTelemetry.Tracer.StartActivity("DebugAllTests");
+        return await StartTestRunAsync("TestExplorer.DebugAllTests", activity);
+    }
+
+    private async Task<bool> StartTestRunAsync(string command, Activity? activity)
+    {
+        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+        var dte = await GetDteAsync();
+
+        // Subscribe before issuing the command, otherwise the run's own state changes are
+        // missed and test_status reports NoRunObserved for a run that is already going.
+        TestExplorer.EnsureTracking();
+
+        try
+        {
+            if (!IsCommandAvailable(dte, command))
+            {
+                return false;
+            }
+
+            dte.ExecuteCommand(command);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            activity?.RecordException(ex);
+            return false;
+        }
+    }
+
+    public async Task<TestTargetResult> RunTestsInContextAsync(string target, bool debug)
+    {
+        using var activity = VsixTelemetry.Tracer.StartActivity(
+            debug ? "DebugTestsInContext" : "RunTestsInContext");
+
+        if (string.IsNullOrWhiteSpace(target))
+        {
+            return new TestTargetResult { Message = "A class or method name is required." };
+        }
+
+        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+        var dte = await GetDteAsync();
+
+        try
+        {
+            var search = await SearchWorkspaceSymbolsAsync(target.Trim());
+            var candidates = search.Symbols
+                .Where(s => s.Kind == SymbolKind.Class || s.Kind == SymbolKind.Function)
+                .ToList();
+
+            var symbol = SelectTestTarget(candidates, target.Trim());
+            if (symbol == null)
+            {
+                return new TestTargetResult
+                {
+                    Message = $"No class or method named '{target}' was found in the solution."
+                };
+            }
+
+            // The *InContext commands act on wherever the caret currently is, so the target has
+            // to be opened and the caret placed on it before the command is issued.
+            if (!await OpenDocumentAsync(symbol.FilePath))
+            {
+                return new TestTargetResult
+                {
+                    ResolvedTarget = symbol.FullName,
+                    FilePath = symbol.FilePath,
+                    Line = symbol.StartLine,
+                    Message = $"Could not open '{symbol.FilePath}' to position the caret."
+                };
+            }
+
+            if (!await SetSelectionAsync(
+                    symbol.FilePath,
+                    symbol.StartLine,
+                    symbol.StartColumn,
+                    symbol.StartLine,
+                    symbol.StartColumn))
+            {
+                return new TestTargetResult
+                {
+                    ResolvedTarget = symbol.FullName,
+                    FilePath = symbol.FilePath,
+                    Line = symbol.StartLine,
+                    Message = $"Could not position the caret on '{symbol.FullName}'."
+                };
+            }
+
+            var command = debug
+                ? "TestExplorer.DebugAllTestsInContext"
+                : "TestExplorer.RunAllTestsInContext";
+
+            TestExplorer.EnsureTracking();
+
+            if (!IsCommandAvailable(dte, command))
+            {
+                return new TestTargetResult
+                {
+                    ResolvedTarget = symbol.FullName,
+                    FilePath = symbol.FilePath,
+                    Line = symbol.StartLine,
+                    Message = $"'{command}' is unavailable. Test Explorer may still be discovering tests."
+                };
+            }
+
+            dte.ExecuteCommand(command);
+
+            return new TestTargetResult
+            {
+                Started = true,
+                ResolvedTarget = symbol.FullName,
+                FilePath = symbol.FilePath,
+                Line = symbol.StartLine,
+                Message = candidates.Count > 1
+                    ? $"{candidates.Count} symbols matched '{target}'; used '{symbol.FullName}'."
+                    : null
+            };
+        }
+        catch (Exception ex)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            activity?.RecordException(ex);
+            return new TestTargetResult { Message = ex.Message };
+        }
+    }
+
+    /// <summary>
+    /// Picks the best match for a caller-supplied class or method name, preferring an exact
+    /// fully qualified match over an exact simple name over a trailing-segment match.
+    /// </summary>
+    internal static SymbolInfo? SelectTestTarget(IReadOnlyList<SymbolInfo> candidates, string target)
+    {
+        return candidates.FirstOrDefault(s => string.Equals(s.FullName, target, StringComparison.Ordinal))
+            ?? candidates.FirstOrDefault(s => string.Equals(s.Name, target, StringComparison.Ordinal))
+            ?? candidates.FirstOrDefault(s => s.FullName.EndsWith("." + target, StringComparison.Ordinal))
+            ?? candidates.FirstOrDefault();
+    }
+
+    public async Task<bool> CancelTestRunAsync()
+    {
+        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+        var dte = await GetDteAsync();
+
+        foreach (var command in CancelTestRunCommands)
+        {
+            try
+            {
+                if (!IsCommandAvailable(dte, command))
+                {
+                    continue;
+                }
+
+                dte.ExecuteCommand(command);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                VsixTelemetry.TrackException(ex);
+            }
+        }
+
+        return false;
+    }
+
+    public async Task<TestRunStatus> GetTestRunStatusAsync()
+    {
+        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+        return TestExplorer.GetRunStatus();
+    }
+
+    public async Task<TestStats> GetTestStatsAsync()
+    {
+        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+        return TestExplorer.GetStats();
+    }
+
+    /// <summary>
+    /// ExecuteCommand throws when a command is disabled or unknown, which for Test Explorer is
+    /// the normal state before discovery finishes. Probing first keeps that an ordinary result
+    /// instead of an exception.
+    /// </summary>
+    private static bool IsCommandAvailable(DTE2 dte, string command)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+
+        try
+        {
+            return dte.Commands.Item(command)?.IsAvailable == true;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
 }


### PR DESCRIPTION
Resolves #101
Resolves #102

Adds seven MCP tools over Test Explorer.

| Tool | Behavior |
|---|---|
| `test_run_all` | Run every test in the solution |
| `test_debug_all` | Debug every test in the solution |
| `test_run` | Run the tests in one class or method |
| `test_debug` | Debug the tests in one class or method |
| `test_cancel` | Cancel the run in progress |
| `test_status` | Run state plus current counts |
| `test_stats` | Passed / failed / skipped / not-run counts |

## One deviation from the issues, with reason

Both issues called for referencing `Microsoft.VisualStudio.TestWindow.Interfaces.dll` from the VS install directory via `$(DevEnvDir)`. **That doesn't work.** I verified before writing any code:

```
$ dotnet msbuild ...MCPServer.csproj -getProperty:DevEnvDir -getProperty:VsInstallRoot
{ "DevEnvDir": "*Undefined*", "VsInstallRoot": "" }
```

`$(DevEnvDir)` is only set when building from a Visual Studio / developer command prompt context. This repo builds with `dotnet build` both locally and in CI (`vsix-build.yml` step 3), so a HintPath reference would have broken the build outright. The assembly is also absent from the `Microsoft.VisualStudio.SDK` metapackage, and nuget.org carries nothing newer than **11.0.61030** (2012), which long predates `ITestExplorerStatsService`.

`TestExplorerInterop` therefore resolves the two services by MEF contract name and reads them reflectively. The alternative — an MSBuild target shelling out to `vswhere` — would have made a Visual Studio installation a hard build prerequisite, which it currently isn't. The tradeoff is losing compile-time type safety across six members; the reflection is confined to one file with the rationale in its `<remarks>`.

## Design notes

**Non-blocking, consistent with #96.** The run tools start the run and return immediately. Completion is observed by *subscribing* to `IOperationState.StateChanged`, not by blocking, so the UI thread is never held — this is specifically not a reintroduction of the `Build(true)` problem that #96 fixed. `test_status` collapses the raw `TestOperationStates` values into `NoRunObserved` / `Discovering` / `Running` / `Canceling` / `Completed` / `Canceled`.

**A discovery pass doesn't erase a run outcome.** Editing code after a run triggers discovery; the state machine keeps the last execution result rather than overwriting it. Covered by a test.

**"Not initialized" is not "no tests".** `ITestExplorerStatsService` reports zeros before Test Explorer starts. `test_stats` checks `IsTestExplorerStatsServiceRunning` and returns an explicit message instead, so an agent can't misread an unopened window as a solution with no tests.

**Caret positioning.** `TestExplorer.RunAllTestsInContext` acts on wherever the caret is, so `test_run` / `test_debug` resolve the name through the existing workspace symbol search, open the file, and place the caret before issuing the command. Resolution prefers exact fully-qualified match, then exact simple name, then trailing segment, and reports when the match was ambiguous.

**Command probing.** `ExecuteCommand` throws when a command is disabled, which for Test Explorer is normal before discovery finishes. Commands are checked with `Command.IsAvailable` first so that's an ordinary result rather than an exception.

**`test_cancel` caveat.** Test Explorer exposes no documented cancel command ID — `RunAllTests`, `DebugAllTests`, `RepeatLastRun` and friends are documented, cancel is not. It probes `TestExplorer.CancelTestRun` then `TestExplorer.CancelTests` and uses whichever the running VS recognizes, reporting cleanly if neither does. Flagging it as the one piece here that would benefit from a check against a live Test Explorer.

## Testing

`dotnet build -c Release` clean, 0 warnings. **36/36 tests pass** (26 added).

Rather than only testing the pure helpers, the tests stand up a real MEF `CompositionContainer` holding stand-in parts declared in the genuine `Microsoft.VisualStudio.TestWindow.Extensibility` namespace and shaped like the shipped ones — including implementing `StateChanged` explicitly, as `OperationBroker` does. That exercises the contract-name lookup, interface discovery, property reads and event subscription, which is where the risk in this approach actually lives.

Not covered automatically: the DTE command invocations and caret positioning, which need a live VS instance.

## Not included

The list of individual failed / not-run test names. As documented in #95, that data is internal and gated behind `InternalsVisibleTo` on Microsoft's strong-name key. `test_stats`' description says counts only, so the limitation is visible to the agent rather than silently surprising.
